### PR TITLE
Update .gitignore and enhance EcovacsMowerApi error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ home-assistant.log*
 secrets.yaml
 known_devices.yaml
 
+# Machine-local artifacts (entire tree ignored).
+/ignored/
+
 # Capture / reverse engineering artifacts
 *.pcap
 *.pcapng

--- a/custom_components/ecovacs_goat_g1/mower_api.py
+++ b/custom_components/ecovacs_goat_g1/mower_api.py
@@ -248,7 +248,7 @@ class EcovacsMowerApi:
                 timeout=TIMEOUT,
             ) as response:
                 response.raise_for_status()
-                result: dict[str, Any] = await response.json(content_type=None)
+                result = await response.json(content_type=None)
                 try:
                     _raise_for_control_error(command, result)
                 except EcovacsApiError as err:
@@ -276,6 +276,10 @@ class EcovacsMowerApi:
                         "response": result,
                     },
                 )
+                # Some firmware (e.g. GOAT O800 RTK) returns HTTP 200 with a JSON null body
+                # for fire-and-forget controls; treat as an empty success envelope.
+                if result is None:
+                    return {}
                 return result
         except ClientError as err:
             self._capture_control_event(
@@ -467,7 +471,7 @@ def app_payload(data: Any) -> dict[str, Any]:
 
 def _raise_for_control_error(command: str, result: Any) -> None:
     """Raise when ECOVACS reports a failed N-GIoT control response."""
-    if result is None and command == "appping":
+    if result is None:
         return
     if not isinstance(result, dict):
         raise EcovacsApiError(f"Control command {command} returned {result!r}")

--- a/tests/ecovacs_goat_g1/test_mower_messages.py
+++ b/tests/ecovacs_goat_g1/test_mower_messages.py
@@ -344,3 +344,9 @@ def test_ngiot_body_code_failure_raises_api_error() -> None:
             "clean_V2",
             {"body": {"code": 500, "msg": "Request Timeout"}},
         )
+
+
+def test_ngiot_null_json_body_is_not_an_error() -> None:
+    """Some models return JSON null on successful control (no structured payload)."""
+    _raise_for_control_error("clean_V2", None)
+    _raise_for_control_error("appping", None)


### PR DESCRIPTION
- Added a rule to .gitignore to exclude machine-local artifacts.
- Modified the EcovacsMowerApi to handle cases where some firmware returns a JSON null body for fire-and-forget controls, treating it as a successful response.
- Updated the error handling logic to simplify checks for null results in control commands.

Made-with: Cursor