### PR TITLE
Fix ECOVACS device verification and durable session reuse

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,6 +59,6 @@ jobs:
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip
-      - run: python -m pip install pytest pytest-asyncio aiohttp paho-mqtt==2.1.0
+      - run: python -m pip install -r requirements-audit.txt
       - run: python -m pytest tests/ecovacs_goat_g1
       - run: python -m compileall custom_components/ecovacs_goat_g1 tests/ecovacs_goat_g1

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ To return to a stable build later, redownload and pick the latest non-beta versi
 
 You need your ECOVACS account username, password, and country. The integration uses the ECOVACS cloud, just like the official app.
 
+If ECOVACS asks Home Assistant to verify its client device, the emailed one-time
+code is used once and is never stored. The account session returned by ECOVACS
+is kept in a separate Home Assistant private store (`0600`, atomic writes), not
+in the config entry or diagnostics. It is removed when the integration entry is
+deleted and is protected by Home Assistant backup encryption when included in
+an encrypted backup. This is operating-system access control, not encryption
+against Home Assistant itself or a host administrator, so protect the HA host
+and use encrypted backups.
+
 During setup, choose a Home Assistant device name. A generated default such as `Ecovacs-GOAT-1` is provided.
 
 ## Optional Dashboard Card

--- a/custom_components/ecovacs_goat_g1/__init__.py
+++ b/custom_components/ecovacs_goat_g1/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 
 from .const import (
+    CONF_SESSION_STORE_ID,
     DOMAIN,
     SERVICE_CLEAR_DEBUG_CAPTURE,
     SERVICE_EXPORT_DEBUG_CAPTURE,
@@ -25,6 +26,8 @@ from .const import (
 )
 from .controller import EcovacsController
 from .frontend import async_register_frontend_card
+from .session_store import async_remove_account_session_store
+from .util import migrate_config_data
 
 PLATFORMS = [
     Platform.BUTTON,
@@ -76,6 +79,20 @@ DEBUG_CAPTURE_EXPORT_SCHEMA = vol.Schema(
 )
 
 
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: EcovacsConfigEntry
+) -> bool:
+    """Persist stable protocol and private-session-store identifiers."""
+    if entry.version > 4:
+        return False
+
+    data = migrate_config_data(entry.data)
+    if entry.version < 4 or data != dict(entry.data):
+        hass.config_entries.async_update_entry(entry, data=data, version=4)
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: EcovacsConfigEntry) -> bool:
     """Set up this integration using UI."""
     # Register the dashboard card first, before the (slow) controller
@@ -101,6 +118,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: EcovacsConfigEntry) -> 
     if unload_ok:
         await entry.runtime_data.teardown()
     return unload_ok
+
+
+async def async_remove_entry(
+    hass: HomeAssistant, entry: EcovacsConfigEntry
+) -> None:
+    """Delete the private account session when its config entry is removed."""
+    # Removal can proceed even if platform unload failed. Drain and tombstone
+    # the controller here as well so no late callback can recreate the store.
+    try:
+        if controller := getattr(entry, "runtime_data", None):
+            await controller.teardown()
+    finally:
+        await async_remove_account_session_store(
+            hass, entry.data.get(CONF_SESSION_STORE_ID)
+        )
 
 
 def _async_register_services(hass: HomeAssistant) -> None:

--- a/custom_components/ecovacs_goat_g1/config_flow.py
+++ b/custom_components/ecovacs_goat_g1/config_flow.py
@@ -8,13 +8,21 @@ from typing import Any
 from aiohttp import ClientError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_COUNTRY, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, selector
 from homeassistant.helpers.typing import VolDictType
 
 from .const import (
+    CONF_DEVICE_ID,
+    CONF_SESSION_STORE_ID,
+    CONF_VERIFICATION_CODE,
     DEFAULT_DEBUG_CAPTURE_MAX_DURATION_MINUTES,
     DEFAULT_DEBUG_CAPTURE_MAX_SIZE_MB,
     DEFAULT_DEBUG_CAPTURE_RAW_PAYLOADS,
@@ -23,53 +31,113 @@ from .const import (
     OPTION_DEBUG_CAPTURE_MAX_SIZE_MB,
     OPTION_DEBUG_CAPTURE_RAW_PAYLOADS,
 )
-from .mower_api import EcovacsApiError, EcovacsAuthError, EcovacsMowerApi
-from .util import get_client_device_id
+from .mower_api import (
+    AccountSession,
+    EcovacsApiError,
+    EcovacsDeviceVerificationRequiredError,
+    EcovacsInvalidAuthError,
+    EcovacsInvalidVerificationCodeError,
+    EcovacsMowerApi,
+)
+from .session_store import AccountSessionStore
+from .util import (
+    generate_client_device_id,
+    generate_session_store_id,
+    get_client_device_id,
+    get_session_store_id,
+)
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME_PREFIX = "Ecovacs-GOAT"
 
 
-async def _validate_input(
-    hass: HomeAssistant, user_input: dict[str, Any]
-) -> dict[str, str]:
-    """Validate user input."""
-    errors: dict[str, str] = {}
-    if not str(user_input.get(CONF_NAME, "")).strip():
-        errors[CONF_NAME] = "invalid_name"
-        return errors
-
-    device_id = get_client_device_id(hass)
-    api = EcovacsMowerApi(
-        aiohttp_client.async_get_clientsession(hass),
-        username=user_input[CONF_USERNAME],
-        password=user_input[CONF_PASSWORD],
-        country=user_input[CONF_COUNTRY],
-        device_id=device_id,
+async def _create_api(
+    hass: HomeAssistant,
+    data: dict[str, Any],
+    *,
+    use_stored_session: bool = True,
+) -> tuple[EcovacsMowerApi, AccountSessionStore]:
+    """Create an API client from pending or persisted config-entry data."""
+    session_store = AccountSessionStore(
+        hass,
+        get_session_store_id(data),
+        get_client_device_id(data),
+        str(data[CONF_USERNAME]),
+        str(data[CONF_COUNTRY]),
     )
+    account_session = (
+        await session_store.async_load() if use_stored_session else None
+    )
+    session_update_callback = None
+    if account_session is not None:
+        persist_seeded_session_updates = True
 
-    try:
-        await api.authenticate()
-        devices = await api.get_devices()
-    except EcovacsAuthError:
-        errors["base"] = "invalid_auth"
-    except (ClientError, EcovacsApiError):
-        _LOGGER.debug("Cannot connect", exc_info=True)
-        errors["base"] = "cannot_connect"
-    except Exception:
-        _LOGGER.exception("Unexpected exception during login")
-        errors["base"] = "unknown"
+        async def _async_persist_seeded_session_update(
+            updated_session: AccountSession | None,
+        ) -> None:
+            """Persist rotations/clears, but defer password fallback sessions."""
+            nonlocal persist_seeded_session_updates
+            if not persist_seeded_session_updates:
+                return
+            await session_store.async_save(updated_session)
+            if updated_session is None:
+                persist_seeded_session_updates = False
 
-    if not errors and not devices:
-        errors["base"] = "unknown"
+        session_update_callback = _async_persist_seeded_session_update
 
-    return errors
+    return EcovacsMowerApi(
+        aiohttp_client.async_get_clientsession(hass),
+        username=data[CONF_USERNAME],
+        password=data[CONF_PASSWORD],
+        country=data[CONF_COUNTRY],
+        device_id=get_client_device_id(data),
+        account_session=account_session,
+        account_session_update_callback=session_update_callback,
+    ), session_store
+
+
+def _enable_verified_session_persistence(
+    api: EcovacsMowerApi, session_store: AccountSessionStore
+) -> None:
+    """Persist a session returned after the user submits a single-use OTP."""
+
+    async def _async_persist_verified_session(
+        updated_session: AccountSession | None,
+    ) -> None:
+        if updated_session is None:
+            await session_store.async_save(None)
+            return
+        await session_store.async_save_verified(updated_session)
+
+    api.set_account_session_update_callback(_async_persist_verified_session)
+
+
+async def _authenticate_and_find_devices(api: EcovacsMowerApi) -> bool:
+    """Authenticate and report whether the account contains a GOAT mower."""
+    await api.authenticate()
+    return bool(await api.get_devices())
+
+
+async def _persist_authenticated_session(
+    api: EcovacsMowerApi, session_store: AccountSessionStore
+) -> None:
+    """Confirm the authenticated session is durable before completing setup."""
+    if api.account_session is None:
+        raise EcovacsInvalidAuthError("ECOVACS account session is missing")
+    await session_store.async_save_verified(api.account_session)
 
 
 class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ecovacs."""
 
-    VERSION = 1
+    VERSION = 4
+
+    def __init__(self) -> None:
+        """Initialize flow-local verification state."""
+        self._verification_api: EcovacsMowerApi | None = None
+        self._verification_data: dict[str, Any] | None = None
+        self._verification_store: AccountSessionStore | None = None
+        self._reauth_entry: ConfigEntry | None = None
 
     @staticmethod
     def async_get_options_flow(config_entry: ConfigEntry) -> EcovacsOptionsFlow:
@@ -79,22 +147,62 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        errors = {}
+        """Handle initial account setup."""
+        errors: dict[str, str] = {}
 
-        if user_input:
+        if user_input is not None:
             self._async_abort_entries_match({CONF_USERNAME: user_input[CONF_USERNAME]})
-            user_input = {
+            data = {
                 **user_input,
                 CONF_NAME: str(user_input[CONF_NAME]).strip(),
+                CONF_DEVICE_ID: generate_client_device_id(),
+                CONF_SESSION_STORE_ID: generate_session_store_id(),
             }
-
-            errors = await _validate_input(self.hass, user_input)
-
-            if not errors:
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
-                )
+            if not data[CONF_NAME]:
+                errors[CONF_NAME] = "invalid_name"
+            else:
+                api, session_store = await _create_api(self.hass, data)
+                try:
+                    has_devices = await _authenticate_and_find_devices(api)
+                    if has_devices:
+                        await _persist_authenticated_session(api, session_store)
+                except EcovacsDeviceVerificationRequiredError:
+                    await session_store.async_save(None)
+                    _enable_verified_session_persistence(api, session_store)
+                    try:
+                        await api.request_device_verification_code()
+                    except EcovacsInvalidAuthError:
+                        errors["base"] = "invalid_auth"
+                    except (ClientError, EcovacsApiError):
+                        _LOGGER.debug(
+                            "Cannot request ECOVACS device verification",
+                            exc_info=True,
+                        )
+                        errors["base"] = "cannot_connect"
+                    except Exception:
+                        _LOGGER.exception(
+                            "Unexpected exception requesting ECOVACS verification"
+                        )
+                        errors["base"] = "unknown"
+                    else:
+                        self._verification_api = api
+                        self._verification_data = data
+                        self._verification_store = session_store
+                        return await self.async_step_device_verification()
+                except EcovacsInvalidAuthError:
+                    await session_store.async_save(None)
+                    errors["base"] = "invalid_auth"
+                except (ClientError, EcovacsApiError):
+                    _LOGGER.debug("Cannot connect to ECOVACS", exc_info=True)
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception("Unexpected exception during ECOVACS login")
+                    errors["base"] = "unknown"
+                else:
+                    if has_devices:
+                        return self.async_create_entry(title=data[CONF_NAME], data=data)
+                    await session_store.async_save(None)
+                    errors["base"] = "no_devices"
 
         schema: VolDictType = {
             vol.Required(CONF_NAME): selector.TextSelector(
@@ -109,26 +217,225 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_COUNTRY): selector.CountrySelector(),
         }
 
-        if not user_input:
-            user_input = {
-                CONF_NAME: self._suggested_name(),
-                CONF_COUNTRY: self.hass.config.country,
-            }
-
+        suggested_values = user_input or {
+            CONF_NAME: self._suggested_name(),
+            CONF_COUNTRY: self.hass.config.country,
+        }
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
-                data_schema=vol.Schema(schema), suggested_values=user_input
+                data_schema=vol.Schema(schema), suggested_values=suggested_values
             ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Start reauthentication for a previously configured account."""
+        self._reauth_entry = self._get_reauth_entry()
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Request an email code only after the user confirms the repair."""
+        if self._reauth_entry is None:
+            return self.async_abort(reason="verification_session_expired")
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            data = dict(self._reauth_entry.data)
+            if new_password := str(user_input.get(CONF_PASSWORD, "")):
+                data[CONF_PASSWORD] = new_password
+            data[CONF_DEVICE_ID] = get_client_device_id(data)
+            data[CONF_SESSION_STORE_ID] = get_session_store_id(data)
+            api, session_store = await _create_api(
+                self.hass,
+                data,
+                use_stored_session=not bool(new_password),
+            )
+            try:
+                has_devices = await _authenticate_and_find_devices(api)
+                if has_devices:
+                    await _persist_authenticated_session(api, session_store)
+            except EcovacsDeviceVerificationRequiredError:
+                await session_store.async_save(None)
+                _enable_verified_session_persistence(api, session_store)
+                try:
+                    await api.request_device_verification_code()
+                except EcovacsInvalidAuthError:
+                    errors["base"] = "invalid_auth"
+                except (ClientError, EcovacsApiError):
+                    _LOGGER.debug(
+                        "Cannot request ECOVACS device verification",
+                        exc_info=True,
+                    )
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception(
+                        "Unexpected exception requesting ECOVACS verification"
+                    )
+                    errors["base"] = "unknown"
+                else:
+                    self._verification_api = api
+                    self._verification_data = data
+                    self._verification_store = session_store
+                    return await self.async_step_device_verification()
+            except EcovacsInvalidAuthError:
+                await session_store.async_save(None)
+                errors["base"] = "invalid_auth"
+            except (ClientError, EcovacsApiError):
+                _LOGGER.debug("Cannot connect to ECOVACS", exc_info=True)
+                if result := await self._async_complete_with_durable_session(
+                    api, session_store, data
+                ):
+                    return result
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during ECOVACS login")
+                if result := await self._async_complete_with_durable_session(
+                    api, session_store, data
+                ):
+                    return result
+                errors["base"] = "unknown"
+            else:
+                if has_devices:
+                    return self.async_update_reload_and_abort(
+                        self._reauth_entry,
+                        data_updates=data,
+                    )
+                await session_store.async_save(None)
+                errors["base"] = "no_devices"
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_PASSWORD): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD
+                        )
+                    )
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "account": str(self._reauth_entry.data[CONF_USERNAME])
+            },
+        )
+
+    async def async_step_device_verification(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Verify the stable device id with the emailed one-time code."""
+        if (
+            self._verification_api is None
+            or self._verification_data is None
+            or self._verification_store is None
+        ):
+            return self.async_abort(reason="verification_session_expired")
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            verification_code = str(user_input[CONF_VERIFICATION_CODE]).strip()
+            if not verification_code:
+                errors[CONF_VERIFICATION_CODE] = "invalid_verification_code"
+            else:
+                try:
+                    await self._verification_api.verify_device(verification_code)
+                    has_devices = bool(await self._verification_api.get_devices())
+                    if has_devices:
+                        await _persist_authenticated_session(
+                            self._verification_api,
+                            self._verification_store,
+                        )
+                except EcovacsInvalidVerificationCodeError:
+                    errors["base"] = "invalid_verification_code"
+                except EcovacsDeviceVerificationRequiredError:
+                    await self._verification_store.async_save(None)
+                    errors["base"] = "invalid_verification_code"
+                except EcovacsInvalidAuthError:
+                    await self._verification_store.async_save(None)
+                    errors["base"] = "invalid_auth"
+                except (ClientError, EcovacsApiError):
+                    _LOGGER.debug(
+                        "Cannot verify the ECOVACS client device", exc_info=True
+                    )
+                    if result := await self._async_complete_with_durable_session(
+                        self._verification_api,
+                        self._verification_store,
+                        self._verification_data,
+                    ):
+                        return result
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception(
+                        "Unexpected exception verifying the ECOVACS client device"
+                    )
+                    if result := await self._async_complete_with_durable_session(
+                        self._verification_api,
+                        self._verification_store,
+                        self._verification_data,
+                    ):
+                        return result
+                    errors["base"] = "unknown"
+                else:
+                    if not has_devices:
+                        await self._verification_store.async_save(None)
+                        errors["base"] = "no_devices"
+                    if has_devices and self._reauth_entry is not None:
+                        return self.async_update_reload_and_abort(
+                            self._reauth_entry,
+                            data_updates=self._verification_data,
+                        )
+                    if has_devices:
+                        return self.async_create_entry(
+                            title=self._verification_data[CONF_NAME],
+                            data=self._verification_data,
+                        )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_VERIFICATION_CODE): selector.TextSelector(
+                    selector.TextSelectorConfig(
+                        type=selector.TextSelectorType.PASSWORD
+                    )
+                )
+            }
+        )
+        return self.async_show_form(
+            step_id="device_verification",
+            data_schema=schema,
             errors=errors,
             last_step=True,
         )
 
+    async def _async_complete_with_durable_session(
+        self,
+        api: EcovacsMowerApi,
+        session_store: AccountSessionStore,
+        data: dict[str, Any],
+    ) -> ConfigFlowResult | None:
+        """Bind an acquired raw session to an entry after a later API failure."""
+        if api.account_session is None:
+            return None
+        try:
+            await session_store.async_save_verified(api.account_session)
+        except Exception:
+            _LOGGER.exception("Cannot persist the ECOVACS account session")
+            return None
+        if self._reauth_entry is not None:
+            return self.async_update_reload_and_abort(
+                self._reauth_entry,
+                data_updates=data,
+            )
+        return self.async_create_entry(title=data[CONF_NAME], data=data)
+
     def _suggested_name(self) -> str:
         """Return the next generic GOAT entry name."""
         existing = {
-            entry.title
-            for entry in self.hass.config_entries.async_entries(DOMAIN)
+            entry.title for entry in self.hass.config_entries.async_entries(DOMAIN)
         }
         number = 1
         while f"{DEFAULT_NAME_PREFIX}-{number}" in existing:

--- a/custom_components/ecovacs_goat_g1/const.py
+++ b/custom_components/ecovacs_goat_g1/const.py
@@ -1,6 +1,9 @@
 """Ecovacs mower constants."""
 
 DOMAIN = "ecovacs_goat_g1"
+CONF_DEVICE_ID = "device_id"
+CONF_SESSION_STORE_ID = "session_store_id"
+CONF_VERIFICATION_CODE = "verification_code"
 SERVICE_REFRESH_STATE = "refresh_state"
 SERVICE_REQUEST_LIVE_POSITION_STREAM = "request_live_position_stream"
 SERVICE_START_DEBUG_CAPTURE = "start_debug_capture"

--- a/custom_components/ecovacs_goat_g1/controller.py
+++ b/custom_components/ecovacs_goat_g1/controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 from dataclasses import replace
 import logging
@@ -11,7 +12,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_COUNTRY, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 
 from .const import (
@@ -23,9 +24,16 @@ from .const import (
     OPTION_DEBUG_CAPTURE_RAW_PAYLOADS,
 )
 from .debug_capture import DebugCaptureStore
-from .mower_api import EcovacsAuthError, EcovacsMowerApi
+from .mower_api import (
+    AccountSession,
+    EcovacsAuthError,
+    EcovacsDeviceVerificationRequiredError,
+    EcovacsInvalidAuthError,
+    EcovacsMowerApi,
+)
 from .mower_coordinator import MowerCoordinator
-from .util import get_client_device_id
+from .session_store import AccountSessionStore
+from .util import get_client_device_id, get_session_store_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,35 +45,55 @@ class EcovacsController:
         """Initialize controller."""
         self._hass = hass
         config: Mapping[str, Any] = entry.data
+        self._config = config
         self._configured_name = str(config.get(CONF_NAME) or "Ecovacs-GOAT")
         self._debug_capture = DebugCaptureStore(
             Path(hass.config.path("ecovacs_goat_g1_debug")),
             Path(hass.config.path("www", "ecovacs_goat", "debug")),
         )
         self._configure_debug_capture(entry.options)
+        self._device_id = get_client_device_id(config)
+        self._session_store = AccountSessionStore(
+            hass,
+            get_session_store_id(config),
+            self._device_id,
+            str(config[CONF_USERNAME]),
+            str(config[CONF_COUNTRY]),
+        )
         for value in (
             config.get(CONF_USERNAME),
             config.get(CONF_PASSWORD),
             self._configured_name,
-            get_client_device_id(hass),
+            self._device_id,
         ):
             self._debug_capture.add_redaction_value(value)
-        self._api = EcovacsMowerApi(
-            aiohttp_client.async_get_clientsession(hass),
-            username=config[CONF_USERNAME],
-            password=config[CONF_PASSWORD],
-            country=config[CONF_COUNTRY],
-            device_id=get_client_device_id(hass),
-            debug_capture=self._debug_capture,
-        )
+        self._api: EcovacsMowerApi | None = None
         self._coordinators: list[MowerCoordinator] = []
+        self._accept_session_updates = True
+        self._session_write_lock = asyncio.Lock()
 
     async def initialize(self) -> None:
         """Initialize mower devices and coordinators."""
         started: list[MowerCoordinator] = []
         try:
-            await self._api.authenticate()
-            devices = await self._api.get_devices()
+            account_session = await self._session_store.async_load()
+            if account_session is not None:
+                self._add_session_redactions(account_session)
+            api = EcovacsMowerApi(
+                aiohttp_client.async_get_clientsession(self._hass),
+                username=self._config[CONF_USERNAME],
+                password=self._config[CONF_PASSWORD],
+                country=self._config[CONF_COUNTRY],
+                device_id=self._device_id,
+                account_session=account_session,
+                account_session_update_callback=(
+                    self._async_account_session_updated
+                ),
+                debug_capture=self._debug_capture,
+            )
+            self._api = api
+            await api.authenticate()
+            devices = await api.get_devices()
             if not devices:
                 raise ConfigEntryNotReady("No ECOVACS mower devices found")
 
@@ -81,7 +109,7 @@ class EcovacsController:
                     self._debug_capture.add_redaction_value(value)
                 coordinator = MowerCoordinator(
                     self._hass,
-                    self._api,
+                    api,
                     device,
                     self._debug_capture,
                 )
@@ -89,8 +117,12 @@ class EcovacsController:
                 started.append(coordinator)
                 _LOGGER.info("Initialized ECOVACS mower %s", device.name)
             self._coordinators = started
+        except EcovacsDeviceVerificationRequiredError as ex:
+            raise ConfigEntryAuthFailed("ECOVACS device verification required") from ex
+        except EcovacsInvalidAuthError as ex:
+            raise ConfigEntryAuthFailed("Invalid ECOVACS credentials") from ex
         except EcovacsAuthError as ex:
-            raise ConfigEntryError("Invalid ECOVACS credentials") from ex
+            raise ConfigEntryNotReady("ECOVACS authentication unavailable") from ex
         except ConfigEntryNotReady:
             await self._stop_coordinators(started)
             raise
@@ -100,15 +132,44 @@ class EcovacsController:
 
     async def teardown(self) -> None:
         """Disconnect controller."""
+        self._accept_session_updates = False
+        # Drain a write that passed the callback gate before entry removal can
+        # delete the store. Later callbacks observe the disabled gate.
+        async with self._session_write_lock:
+            pass
         await self._stop_coordinators(self._coordinators)
         self._coordinators.clear()
+
+    async def _async_account_session_updated(
+        self, account_session: AccountSession | None
+    ) -> None:
+        """Persist session rotations and definitive invalidation privately."""
+        async with self._session_write_lock:
+            if not self._accept_session_updates:
+                return
+            if account_session is not None:
+                self._add_session_redactions(account_session)
+            await self._session_store.async_save(account_session)
+
+    def _add_session_redactions(self, account_session: AccountSession) -> None:
+        """Ensure raw account credentials never appear in debug captures."""
+        self._debug_capture.add_redaction_value(account_session.user_id)
+        self._debug_capture.add_redaction_value(account_session.access_token)
 
     async def _stop_coordinators(
         self, coordinators: list[MowerCoordinator]
     ) -> None:
-        """Stop any coordinators that were already started."""
-        for coordinator in coordinators:
-            await coordinator.async_stop()
+        """Best-effort stop every coordinator that was already started."""
+        results = await asyncio.gather(
+            *(coordinator.async_stop() for coordinator in coordinators),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                _LOGGER.warning(
+                    "Error stopping an ECOVACS mower coordinator",
+                    exc_info=(type(result), result, result.__traceback__),
+                )
 
     @property
     def coordinators(self) -> list[MowerCoordinator]:

--- a/custom_components/ecovacs_goat_g1/debug_capture.py
+++ b/custom_components/ecovacs_goat_g1/debug_capture.py
@@ -18,6 +18,7 @@ DEFAULT_RETAINED_SESSIONS = 3
 REDACTED = "<redacted>"
 REDACT_KEYS = {
     "accessToken",
+    "access_token",
     "auth",
     "authCode",
     "authorization",
@@ -31,6 +32,7 @@ REDACT_KEYS = {
     "resource",
     "token",
     "uid",
+    "user_id",
     "userId",
     "userid",
 }
@@ -272,7 +274,8 @@ class DebugCaptureStore:
             "max_bytes": self._session.max_bytes,
         }
         (self._session.path / "manifest.json").write_text(
-            json.dumps(manifest, indent=2), encoding="utf-8"
+            json.dumps(self._redact(_json_safe(manifest)), indent=2),
+            encoding="utf-8",
         )
 
     def _stop_locked(self, reason: str) -> None:
@@ -283,7 +286,10 @@ class DebugCaptureStore:
         manifest = _read_json(manifest_path)
         manifest["stopped_at"] = _utc_now()
         manifest["stop_reason"] = reason
-        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        manifest_path.write_text(
+            json.dumps(self._redact(_json_safe(manifest)), indent=2),
+            encoding="utf-8",
+        )
         self._session = None
         self._event_path = None
 

--- a/custom_components/ecovacs_goat_g1/diagnostics.py
+++ b/custom_components/ecovacs_goat_g1/diagnostics.py
@@ -9,10 +9,13 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from . import EcovacsConfigEntry
+from .const import CONF_DEVICE_ID, CONF_SESSION_STORE_ID
 
 REDACT_CONFIG = {
     CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_DEVICE_ID,
+    CONF_SESSION_STORE_ID,
     "title",
 }
 REDACT_DEVICE = {"did", "name", "nick", "homeId"}

--- a/custom_components/ecovacs_goat_g1/mower_api.py
+++ b/custom_components/ecovacs_goat_g1/mower_api.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+import base64
+import binascii
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
 from datetime import datetime
 import hashlib
 import json
@@ -12,6 +16,8 @@ from urllib.parse import urljoin
 from uuid import uuid4
 
 from aiohttp import ClientError, ClientResponseError, ClientSession, ClientTimeout
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from .debug_capture import DebugCaptureStore
 from .mower_models import MowerDevice
@@ -28,10 +34,11 @@ AUTH_CLIENT_KEY = "1520391491841"
 # Same as above for the auth-code client.
 AUTH_CLIENT_SECRET = "77ef58ce3afbe337da74aa8c5ab963a9"  # nosemgrep
 GLOBAL_AUTHCODE_PATH = "/v1/global/auth/getAuthCode"
-USER_LOGIN_PATH_FORMAT = (
-    "/v1/private/{country}/{lang}/{deviceId}/{appCode}/{appVersion}/"
-    "{channel}/{deviceType}/user/login"
+PRIVATE_API_PATH_FORMAT = (
+    "/{apiVersion}/private/{country}/{lang}/{deviceId}/{appCode}/{appVersion}/"
+    "{channel}/{deviceType}/{endpoint}"
 )
+PUBLIC_KEY_CONFIG = "PUBLIC.KEY.CONFIG"
 META = {
     "lang": "EN",
     "appCode": "global_e",
@@ -39,6 +46,9 @@ META = {
     "channel": "google_play",
     "deviceType": "1",
 }
+VERIFICATION_META = {**META, "appVersion": "3.14.0"}
+ANDROID_MODEL = "Pixel 7"
+ANDROID_SYSTEM = "Android 14"
 TIMEOUT = ClientTimeout(total=60)
 EU_COUNTRIES = {
     "AD",
@@ -102,12 +112,37 @@ class EcovacsAuthError(EcovacsApiError):
     """Authentication failed."""
 
 
+class EcovacsInvalidAuthError(EcovacsAuthError):
+    """The ECOVACS account credentials are invalid."""
+
+
+class EcovacsDeviceVerificationRequiredError(EcovacsAuthError):
+    """The client device must be verified before authentication."""
+
+
+class EcovacsInvalidVerificationCodeError(EcovacsInvalidAuthError):
+    """The device-verification code is invalid or expired."""
+
+
+@dataclass(frozen=True)
+class AccountSession:
+    """Private ECOVACS account session returned by login or verification."""
+
+    user_id: str = field(repr=False)
+    access_token: str = field(repr=False)
+
+
+AccountSessionUpdateCallback = Callable[
+    [AccountSession | None], Awaitable[None]
+]
+
+
 @dataclass(frozen=True)
 class Credentials:
     """ECOVACS credentials."""
 
-    user_id: str
-    token: str
+    user_id: str = field(repr=False)
+    token: str = field(repr=False)
     expires_at: float
 
 
@@ -115,7 +150,7 @@ class Credentials:
 class SstToken:
     """Short-lived N-GIoT control token."""
 
-    token: str
+    token: str = field(repr=False)
     expires_at: float
 
 
@@ -130,6 +165,8 @@ class EcovacsMowerApi:
         password: str,
         country: str,
         device_id: str,
+        account_session: AccountSession | None = None,
+        account_session_update_callback: AccountSessionUpdateCallback | None = None,
         debug_capture: DebugCaptureStore | None = None,
     ) -> None:
         self._session = session
@@ -138,9 +175,20 @@ class EcovacsMowerApi:
         self._country = country.upper()
         self._device_id = device_id
         self._continent = country_continent(self._country)
+        self._account_session = account_session
+        self._account_session_update_callback = account_session_update_callback
         self._credentials: Credentials | None = None
+        self._auth_lock = asyncio.Lock()
         self._sst: dict[str, SstToken] = {}
         self._debug_capture = debug_capture
+
+        self._meta: dict[str, str] = {
+            **META,
+            "country": country_api_code(self._country),
+            "deviceId": self._device_id,
+        }
+        self._verification_meta = {**self._meta, **VERIFICATION_META}
+        self._public_key: rsa.RSAPublicKey | None = None
 
         postfix = "" if self._country == COUNTRY_CHINA else f"-{self._continent}"
         country_lower = self._country.lower()
@@ -160,26 +208,165 @@ class EcovacsMowerApi:
         """Return the client resource used for account login."""
         return self._device_id
 
+    @property
+    def account_session(self) -> AccountSession | None:
+        """Return the private account session currently held in memory."""
+        return self._account_session
+
+    def set_account_session_update_callback(
+        self, callback: AccountSessionUpdateCallback | None
+    ) -> None:
+        """Replace the private-session persistence sink."""
+        self._account_session_update_callback = callback
+
     async def authenticate(self, *, force: bool = False) -> Credentials:
         """Authenticate and cache ECOVACS account credentials."""
-        if (
-            self._credentials is None
-            or force
-            or self._credentials.expires_at < time.time()
-        ):
+        if self._credentials_are_current(force):
+            return self._credentials  # type: ignore[return-value]
+
+        async with self._auth_lock:
+            if self._credentials_are_current(force):
+                return self._credentials  # type: ignore[return-value]
+
+            if self._account_session is not None:
+                try:
+                    refreshed_session = await self._check_login(
+                        self._account_session
+                    )
+                    # The official client persists a potentially rotated raw
+                    # session before minting its IoT/portal credentials.
+                    await self._async_set_account_session(refreshed_session)
+                    self._credentials = await self._complete_login(
+                        refreshed_session.user_id,
+                        refreshed_session.access_token,
+                    )
+                    return self._credentials
+                except (
+                    EcovacsInvalidAuthError,
+                    EcovacsDeviceVerificationRequiredError,
+                ):
+                    # Only a definitive authentication response invalidates a
+                    # saved session. Transport/server errors retain it and are
+                    # allowed to propagate without a password fallback.
+                    await self._async_set_account_session(None)
+
             login_resp = await self._login_password()
-            user_id = login_resp["uid"]
-            auth_code = await self._auth_code(login_resp["accessToken"], user_id)
-            token_resp = await self._login_by_it_token(user_id, auth_code)
-            if token_resp["userId"] != user_id:
-                user_id = token_resp["userId"]
-            expires_at = time.time() + int(token_resp.get("last", 604800)) / 1000 * 0.99
-            self._credentials = Credentials(
-                user_id=user_id,
-                token=token_resp["token"],
-                expires_at=expires_at,
+            account_session = _parse_account_session(login_resp, "login")
+            # Persist the reusable account session before the secondary portal
+            # exchange.  A transient portal failure must not force another
+            # password/device-verification round trip.
+            await self._async_set_account_session(account_session)
+            try:
+                credentials = await self._complete_login(
+                    account_session.user_id,
+                    account_session.access_token,
+                )
+            except (
+                EcovacsInvalidAuthError,
+                EcovacsDeviceVerificationRequiredError,
+            ):
+                await self._async_set_account_session(None)
+                raise
+            self._credentials = credentials
+            return credentials
+
+    def _credentials_are_current(self, force: bool) -> bool:
+        """Return whether cached portal credentials can be reused."""
+        return (
+            not force
+            and self._credentials is not None
+            and self._credentials.expires_at >= time.time()
+        )
+
+    async def _async_set_account_session(
+        self, account_session: AccountSession | None
+    ) -> None:
+        """Update the in-memory session and its optional private-store sink."""
+        self._account_session = account_session
+        if self._account_session_update_callback is not None:
+            # Do not skip an equal value: retrying the sink is important if an
+            # earlier atomic write failed after the in-memory value changed.
+            await self._account_session_update_callback(account_session)
+
+    async def request_device_verification_code(self) -> None:
+        """Request a one-time email code for this stable client device ID."""
+        encrypted_email = await self._encrypt_account(self._username)
+        await self._call_private_api(
+            "user/sendEmailVerifyCode",
+            {
+                "encryptEmail": encrypted_email,
+                "verifyType": "EMAIL_VERIFY_DEVICE",
+                "supportChar": "N",
+                "isForce": "N",
+                **self._request_metadata(),
+            },
+        )
+
+    async def verify_device(self, verification_code: str) -> Credentials:
+        """Verify this stable client device ID and complete authentication."""
+        encrypted_account = await self._encrypt_account(self._username)
+        response = await self._call_private_api(
+            "user/verifyDevice",
+            {
+                "encryptAccount": encrypted_account,
+                "backUpEmail": "",
+                "verifyCode": verification_code.strip(),
+                "model": ANDROID_MODEL,
+                "system": ANDROID_SYSTEM,
+                **self._request_metadata(),
+            },
+        )
+        if not isinstance(response, dict):
+            raise EcovacsAuthError("Invalid verifyDevice response")
+        account_session = _parse_account_session(response, "verifyDevice")
+        # The verification code is single-use.  Make its returned session
+        # durable before any fallible portal exchange so setup can resume
+        # without asking the user to submit that code again.
+        await self._async_set_account_session(account_session)
+        try:
+            self._credentials = await self._complete_login(
+                account_session.user_id,
+                account_session.access_token,
             )
+        except (
+            EcovacsInvalidAuthError,
+            EcovacsDeviceVerificationRequiredError,
+        ):
+            await self._async_set_account_session(None)
+            raise
         return self._credentials
+
+    async def _check_login(self, account_session: AccountSession) -> AccountSession:
+        """Validate and rotate a persisted account session like the official app."""
+        response = await self._call_private_api(
+            "user/checkLogin",
+            {
+                "uid": account_session.user_id,
+                "accessToken": account_session.access_token,
+                **self._request_metadata(),
+            },
+            api_version="v2",
+        )
+        if not isinstance(response, dict):
+            raise EcovacsAuthError("Invalid checkLogin response")
+        return _parse_account_session(response, "checkLogin")
+
+    async def _complete_login(
+        self, user_id: str, access_token: str
+    ) -> Credentials:
+        """Exchange an ECOVACS access token for portal credentials."""
+        auth_code = await self._auth_code(access_token, user_id)
+        token_resp = await self._login_by_it_token(user_id, auth_code)
+        if token_resp["userId"] != user_id:
+            user_id = token_resp["userId"]
+        expires_at = (
+            time.time() + int(token_resp.get("last", 604800)) / 1000 * 0.99
+        )
+        return Credentials(
+            user_id=user_id,
+            token=token_resp["token"],
+            expires_at=expires_at,
+        )
 
     async def get_devices(self) -> list[MowerDevice]:
         """Return mower-like eco-ng devices from the account."""
@@ -360,20 +547,101 @@ class EcovacsMowerApi:
         return cached
 
     async def _login_password(self) -> dict[str, Any]:
-        meta = {
-            **META,
-            "country": country_api_code(self._country),
-            "deviceId": self._device_id,
-        }
         params: dict[str, str | int] = {
             "account": self._username,
             "password": self._password_hash,
-            "requestId": md5(str(time.time())),
-            "authTimespan": int(time.time() * 1000),
+            **self._request_metadata(),
+        }
+        url = urljoin(
+            self._login_url,
+            PRIVATE_API_PATH_FORMAT.format(
+                apiVersion="v1", endpoint="user/login", **self._meta
+            ),
+        )
+        response = await self._signed_get(
+            url, params, self._meta, CLIENT_KEY, CLIENT_SECRET
+        )
+        if not isinstance(response, dict):
+            raise EcovacsAuthError("Invalid login response")
+        return response
+
+    async def _call_private_api(
+        self,
+        endpoint: str,
+        params: dict[str, str | int],
+        *,
+        api_version: str = "v1",
+    ) -> Any:
+        """Call a signed private authentication endpoint."""
+        url = urljoin(
+            self._login_url,
+            PRIVATE_API_PATH_FORMAT.format(
+                apiVersion=api_version,
+                endpoint=endpoint,
+                **self._verification_meta,
+            ),
+        )
+        return await self._signed_get(
+            url,
+            params,
+            self._verification_meta,
+            CLIENT_KEY,
+            CLIENT_SECRET,
+        )
+
+    @staticmethod
+    def _request_metadata() -> dict[str, str | int]:
+        """Return per-request metadata used by ECOVACS signing."""
+        now = time.time()
+        return {
+            "requestId": md5(str(now)),
+            "authTimespan": int(now * 1000),
             "authTimeZone": "GMT-8",
         }
-        url = urljoin(self._login_url, USER_LOGIN_PATH_FORMAT.format(**meta))
-        return await self._signed_get(url, params, meta, CLIENT_KEY, CLIENT_SECRET)
+
+    async def _get_public_key(self) -> rsa.RSAPublicKey:
+        """Fetch and cache the ECOVACS account-encryption public key."""
+        if self._public_key is not None:
+            return self._public_key
+
+        response = await self._call_private_api(
+            "common/getConfig",
+            {"keys": PUBLIC_KEY_CONFIG, **self._request_metadata()},
+        )
+        if not isinstance(response, list):
+            raise EcovacsAuthError("Invalid public key configuration response")
+
+        for entry in response:
+            if not isinstance(entry, dict) or entry.get("key") != PUBLIC_KEY_CONFIG:
+                continue
+            value = entry.get("value")
+            if not isinstance(value, str):
+                break
+            try:
+                config = json.loads(value)
+                encoded_key = config["publicKey"]
+            except (KeyError, TypeError, json.JSONDecodeError) as err:
+                raise EcovacsAuthError("Invalid ECOVACS public key") from err
+            if not isinstance(encoded_key, str):
+                raise EcovacsAuthError("Invalid ECOVACS public key")
+            try:
+                key = serialization.load_der_public_key(
+                    base64.b64decode(encoded_key, validate=True)
+                )
+            except (binascii.Error, TypeError, ValueError) as err:
+                raise EcovacsAuthError("Invalid ECOVACS public key") from err
+            if not isinstance(key, rsa.RSAPublicKey):
+                raise EcovacsAuthError("ECOVACS public key is not RSA")
+            self._public_key = key
+            return key
+
+        raise EcovacsAuthError("ECOVACS public key configuration is missing")
+
+    async def _encrypt_account(self, account: str) -> str:
+        """Encrypt an account identifier for the private verification API."""
+        public_key = await self._get_public_key()
+        encrypted = public_key.encrypt(account.encode(), padding.PKCS1v15())
+        return base64.b64encode(encrypted).decode()
 
     async def _auth_code(self, access_token: str, user_id: str) -> str:
         params: dict[str, str | int] = {
@@ -407,26 +675,49 @@ class EcovacsMowerApi:
                 return response
             if response.get("result") == "fail" and response.get("error") == "set token error.":
                 continue
-            raise EcovacsAuthError(f"loginByItToken failed: {response}")
+            raise EcovacsAuthError("loginByItToken failed")
         raise EcovacsAuthError("loginByItToken failed after retries")
 
     async def _signed_get(
         self,
         url: str,
         params: dict[str, str | int],
-        extra: dict[str, str | int],
+        extra: Mapping[str, str | int],
         key: str,
         secret: str,
-    ) -> dict[str, Any]:
+    ) -> Any:
         signed = sign_params(params, extra, key, secret)
-        async with self._session.get(url, params=signed, timeout=TIMEOUT) as response:
-            response.raise_for_status()
-            result: dict[str, Any] = await response.json(content_type=None)
-        if result.get("code") == "0000":
-            return result["data"]
-        if result.get("code") in ("1005", "1010"):
-            raise EcovacsAuthError("invalid credentials")
-        raise EcovacsAuthError(f"auth call failed: {result}")
+        try:
+            async with self._session.get(
+                url, params=signed, timeout=TIMEOUT
+            ) as response:
+                response.raise_for_status()
+                result = await response.json(content_type=None)
+        except (ClientError, TimeoutError, ValueError):
+            # ClientResponseError includes the full request URL. Authentication
+            # requests carry tokens or OTPs in the query string, so deliberately
+            # suppress exception chaining before callers log this error.
+            raise EcovacsApiError("Authentication request failed") from None
+        if not isinstance(result, dict):
+            raise EcovacsAuthError("Invalid authentication response")
+
+        code = str(result.get("code", ""))
+        if code == "0000":
+            return result.get("data")
+        if code in ("1005", "1010"):
+            raise EcovacsInvalidAuthError("Invalid ECOVACS credentials")
+        if code == "1012":
+            raise EcovacsInvalidVerificationCodeError(
+                "Invalid or expired verification code"
+            )
+        if code == "1013":
+            raise EcovacsDeviceVerificationRequiredError(
+                "ECOVACS device verification required"
+            )
+        safe_code = code if code.isdigit() and len(code) <= 8 else "unknown"
+        raise EcovacsAuthError(
+            f"Authentication call failed with code {safe_code}"
+        )
 
     async def _post_authenticated(
         self, path: str, data: dict[str, Any]
@@ -453,6 +744,19 @@ class EcovacsMowerApi:
                 return result
         except ClientResponseError as err:
             raise EcovacsApiError(f"POST {path} failed") from err
+
+
+def _parse_account_session(
+    response: Mapping[str, Any], source: str
+) -> AccountSession:
+    """Return a validated raw account session without exposing its values."""
+    user_id = response.get("uid")
+    access_token = response.get("accessToken")
+    if not isinstance(user_id, str) or not user_id:
+        raise EcovacsAuthError(f"Invalid {source} response")
+    if not isinstance(access_token, str) or not access_token:
+        raise EcovacsAuthError(f"Invalid {source} response")
+    return AccountSession(user_id=user_id, access_token=access_token)
 
 
 def app_payload(data: Any) -> dict[str, Any]:
@@ -505,7 +809,7 @@ def _raise_for_control_error(command: str, result: Any) -> None:
 
 def sign_params(
     params: dict[str, str | int],
-    extra: dict[str, str | int],
+    extra: Mapping[str, str | int],
     key: str,
     secret: str,
 ) -> dict[str, str | int]:

--- a/custom_components/ecovacs_goat_g1/session_store.py
+++ b/custom_components/ecovacs_goat_g1/session_store.py
@@ -1,0 +1,137 @@
+"""Private persistence for the ECOVACS account session."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+from .mower_api import AccountSession
+from .util import is_valid_session_store_id
+
+STORAGE_VERSION = 1
+
+
+class AccountSessionStoreError(RuntimeError):
+    """The private account session could not be made durable."""
+
+
+class AccountSessionStore:
+    """Persist one account session in a mode-0600 Home Assistant store."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        store_id: str,
+        client_device_id: str,
+        username: str,
+        country: str,
+    ) -> None:
+        """Initialize a private, atomic store bound to one config entry."""
+        self._store = Store[dict[str, Any]](
+            hass,
+            STORAGE_VERSION,
+            f"{DOMAIN}/auth_{store_id}",
+            private=True,
+            atomic_writes=True,
+        )
+        self._client_device_id = client_device_id
+        self._account_fingerprint = _account_fingerprint(
+            username, country, client_device_id
+        )
+
+    async def async_load(self) -> AccountSession | None:
+        """Load a complete session, removing malformed or misbound data."""
+        data = await self._store.async_load()
+        if not isinstance(data, dict):
+            if data is not None:
+                await self._store.async_remove()
+            return None
+        if data.get("client_device_id") != self._client_device_id:
+            await self._store.async_remove()
+            return None
+        if data.get("account_fingerprint") != self._account_fingerprint:
+            await self._store.async_remove()
+            return None
+        user_id = data.get("user_id")
+        access_token = data.get("access_token")
+        if not isinstance(user_id, str) or not user_id:
+            await self._store.async_remove()
+            return None
+        if not isinstance(access_token, str) or not access_token:
+            await self._store.async_remove()
+            return None
+        return AccountSession(user_id=user_id, access_token=access_token)
+
+    async def async_save(self, session: AccountSession | None) -> None:
+        """Atomically save a session, or remove the store when it is invalid."""
+        if session is None:
+            await self._store.async_remove()
+            return
+        await self._store.async_save(
+            {
+                "client_device_id": self._client_device_id,
+                "account_fingerprint": self._account_fingerprint,
+                "user_id": session.user_id,
+                "access_token": session.access_token,
+            }
+        )
+
+    async def async_save_verified(self, session: AccountSession) -> None:
+        """Save and read back a session across the one-time-code boundary."""
+        await self.async_save(session)
+        if await self.async_load() != session:
+            raise AccountSessionStoreError(
+                "ECOVACS account session was not written to private storage"
+            )
+
+    async def async_remove(self) -> None:
+        """Remove the persisted account session."""
+        await self._store.async_remove()
+
+
+async def async_remove_account_session_store(
+    hass: HomeAssistant, store_id: Any
+) -> None:
+    """Remove a private store by opaque id without requiring entry migration."""
+    if not is_valid_session_store_id(store_id):
+        return
+    store = Store[dict[str, Any]](
+        hass,
+        STORAGE_VERSION,
+        f"{DOMAIN}/auth_{store_id}",
+        private=True,
+        atomic_writes=True,
+    )
+    await store.async_remove()
+    storage_dir = Path(hass.config.path(".storage", DOMAIN))
+    await hass.async_add_executor_job(
+        _remove_corrupt_store_siblings,
+        storage_dir,
+        f"auth_{store_id}.corrupt.",
+    )
+
+
+def _account_fingerprint(
+    username: str, country: str, client_device_id: str
+) -> str:
+    """Return a non-reversible binding for the configured account identity."""
+    material = "\0".join(
+        (username.strip().casefold(), country.upper(), client_device_id)
+    )
+    return hashlib.sha256(material.encode()).hexdigest()
+
+
+def _remove_corrupt_store_siblings(
+    storage_dir: Path, filename_prefix: str
+) -> None:
+    """Remove private corrupt-file remnants belonging to a deleted entry."""
+    if not storage_dir.is_dir():
+        return
+    for candidate in storage_dir.iterdir():
+        if candidate.is_file() and candidate.name.startswith(filename_prefix):
+            candidate.unlink()

--- a/custom_components/ecovacs_goat_g1/strings.json
+++ b/custom_components/ecovacs_goat_g1/strings.json
@@ -1,13 +1,16 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "verification_session_expired": "The device-verification session expired. Start the repair flow again to request a new code."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "invalid_name": "Enter a name."
+      "invalid_name": "Enter a name.",
+      "invalid_verification_code": "The verification code is invalid or expired.",
+      "no_devices": "No ECOVACS GOAT mower was found on this account."
     },
     "step": {
       "user": {
@@ -16,6 +19,20 @@
           "country": "[%key:common::config_flow::data::country%]",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Verify ECOVACS client device",
+        "description": "Repair authentication for {account}. If the password changed, enter the new one; otherwise leave it blank. Home Assistant first retries normal login and sends an email code only if ECOVACS still requires device verification.",
+        "data": {
+          "password": "New password (leave blank to keep the saved password)"
+        }
+      },
+      "device_verification": {
+        "title": "Enter ECOVACS verification code",
+        "description": "Enter the one-time code ECOVACS emailed you. The code itself is never stored. The account session returned by ECOVACS is saved in Home Assistant private local storage so the integration can survive restarts.",
+        "data": {
+          "verification_code": "Verification code"
         }
       }
     }

--- a/custom_components/ecovacs_goat_g1/util.py
+++ b/custom_components/ecovacs_goat_g1/util.py
@@ -2,10 +2,77 @@
 
 from __future__ import annotations
 
-from homeassistant.core import HomeAssistant
-from homeassistant.util import slugify
+from collections.abc import Mapping
+import secrets
+import string
+from typing import Any
+
+from .const import CONF_DEVICE_ID, CONF_SESSION_STORE_ID
+
+CLIENT_DEVICE_ID_LENGTH = 8
+CLIENT_DEVICE_ID_ALPHABET = string.ascii_uppercase + string.digits
+SESSION_STORE_ID_LENGTH = 32
+SESSION_STORE_ID_ALPHABET = string.hexdigits.lower()[:16]
 
 
-def get_client_device_id(hass: HomeAssistant) -> str:
-    """Get client device id."""
-    return f"HA-{slugify(hass.config.location_name)}"
+def generate_client_device_id() -> str:
+    """Generate the exact eight-character id expected by ECOVACS clients."""
+    return "".join(
+        secrets.choice(CLIENT_DEVICE_ID_ALPHABET)
+        for _ in range(CLIENT_DEVICE_ID_LENGTH)
+    )
+
+
+def generate_session_store_id() -> str:
+    """Generate an opaque id for the private account-session store."""
+    return secrets.token_hex(SESSION_STORE_ID_LENGTH // 2)
+
+
+def is_valid_session_store_id(store_id: Any) -> bool:
+    """Return whether a private-store id is safe to use in a storage key."""
+    return (
+        isinstance(store_id, str)
+        and len(store_id) == SESSION_STORE_ID_LENGTH
+        and all(character in SESSION_STORE_ID_ALPHABET for character in store_id)
+    )
+
+
+def is_valid_client_device_id(device_id: Any) -> bool:
+    """Return whether a value matches ECOVACS' client-device id format."""
+    return (
+        isinstance(device_id, str)
+        and len(device_id) == CLIENT_DEVICE_ID_LENGTH
+        and all(character in CLIENT_DEVICE_ID_ALPHABET for character in device_id)
+    )
+
+
+def migrate_client_device_id(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return config data with one stable ECOVACS-compatible device id."""
+    data = dict(config)
+    if not is_valid_client_device_id(data.get(CONF_DEVICE_ID)):
+        data[CONF_DEVICE_ID] = generate_client_device_id()
+    return data
+
+
+def migrate_config_data(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return config data with stable protocol and private-store identifiers."""
+    data = migrate_client_device_id(config)
+    if not is_valid_session_store_id(data.get(CONF_SESSION_STORE_ID)):
+        data[CONF_SESSION_STORE_ID] = generate_session_store_id()
+    return data
+
+
+def get_client_device_id(config: Mapping[str, Any]) -> str:
+    """Return the persisted ECOVACS-compatible client id."""
+    device_id = config.get(CONF_DEVICE_ID)
+    if is_valid_client_device_id(device_id):
+        return device_id
+    raise ValueError("ECOVACS client device id is missing or invalid")
+
+
+def get_session_store_id(config: Mapping[str, Any]) -> str:
+    """Return the validated opaque id for private account-session storage."""
+    store_id = config.get(CONF_SESSION_STORE_ID)
+    if is_valid_session_store_id(store_id):
+        return store_id
+    raise ValueError("ECOVACS private session store id is missing or invalid")

--- a/requirements-audit.txt
+++ b/requirements-audit.txt
@@ -2,4 +2,7 @@
 # custom_components/ecovacs_goat_g1/manifest.json and .github/workflows/validate.yml.
 paho-mqtt==2.1.0
 pytest
+pytest-asyncio
 aiohttp
+cryptography
+voluptuous

--- a/tests/ecovacs_goat_g1/test_config_flow_verification.py
+++ b/tests/ecovacs_goat_g1/test_config_flow_verification.py
@@ -1,0 +1,861 @@
+"""State-machine tests for the ECOVACS verification config flow."""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+import re
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import voluptuous as vol
+
+PACKAGE_PATH = Path(__file__).parents[2] / "custom_components" / "ecovacs_goat_g1"
+
+
+class _Selector:
+    def __init__(self, _config: Any = None) -> None:
+        pass
+
+    def __call__(self, value: Any) -> Any:
+        return value
+
+
+class _SelectorConfig:
+    def __init__(self, **_kwargs: Any) -> None:
+        pass
+
+
+class _ConfigEntry:
+    def __init__(
+        self,
+        data: dict[str, Any],
+        title: str = "GOAT",
+        version: int = 3,
+    ) -> None:
+        self.data = data
+        self.title = title
+        self.version = version
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"title": self.title, "data": dict(self.data)}
+
+
+class _ConfigFlow:
+    def __init_subclass__(cls, *, domain: str | None = None, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls.domain = domain
+
+    def _async_abort_entries_match(self, _match: dict[str, Any]) -> None:
+        pass
+
+    def _get_reauth_entry(self) -> _ConfigEntry:
+        return self._test_reauth_entry
+
+    @staticmethod
+    def add_suggested_values_to_schema(
+        data_schema: vol.Schema, suggested_values: dict[str, Any]
+    ) -> vol.Schema:
+        return data_schema
+
+    @staticmethod
+    def async_show_form(**kwargs: Any) -> dict[str, Any]:
+        return {"type": "form", **kwargs}
+
+    @staticmethod
+    def async_create_entry(**kwargs: Any) -> dict[str, Any]:
+        return {"type": "create_entry", **kwargs}
+
+    @staticmethod
+    def async_abort(**kwargs: Any) -> dict[str, Any]:
+        return {"type": "abort", **kwargs}
+
+    @staticmethod
+    def async_update_reload_and_abort(
+        entry: _ConfigEntry, *, data_updates: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "type": "abort",
+            "reason": "reauth_successful",
+            "entry": entry,
+            "data_updates": data_updates,
+        }
+
+
+class _OptionsFlow:
+    @staticmethod
+    def async_create_entry(**kwargs: Any) -> dict[str, Any]:
+        return {"type": "create_entry", **kwargs}
+
+    @staticmethod
+    def async_show_form(**kwargs: Any) -> dict[str, Any]:
+        return {"type": "form", **kwargs}
+
+
+class _ConfigEntries:
+    @staticmethod
+    def async_entries(_domain: str) -> list[Any]:
+        return []
+
+
+class _Hass:
+    config = types.SimpleNamespace(
+        country="RO", location_name="Home", path=lambda *_args: "/tmp"
+    )
+    config_entries = _ConfigEntries()
+
+    async def async_add_executor_job(
+        self, target: Any, *args: Any
+    ) -> Any:
+        return target(*args)
+
+
+class _Store:
+    """Minimal Home Assistant Store stub with inspectable constructor flags."""
+
+    def __class_getitem__(cls, _item: Any) -> type[_Store]:
+        return cls
+
+    def __init__(
+        self,
+        hass: Any,
+        version: int,
+        key: str,
+        **kwargs: Any,
+    ) -> None:
+        self.hass = hass
+        self.version = version
+        self.key = key
+        self.kwargs = kwargs
+        self.data: Any = None
+        self.removed = False
+
+    async def async_load(self) -> Any:
+        return self.data
+
+    async def async_save(self, data: Any) -> None:
+        self.data = data
+
+    async def async_remove(self) -> None:
+        self.removed = True
+        self.data = None
+
+
+def _install_homeassistant_stubs() -> None:
+    homeassistant = types.ModuleType("homeassistant")
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = _ConfigEntry
+    config_entries.ConfigFlow = _ConfigFlow
+    config_entries.ConfigFlowResult = dict
+    config_entries.OptionsFlow = _OptionsFlow
+
+    const = types.ModuleType("homeassistant.const")
+    const.CONF_COUNTRY = "country"
+    const.CONF_NAME = "name"
+    const.CONF_PASSWORD = "password"
+    const.CONF_USERNAME = "username"
+
+    core = types.ModuleType("homeassistant.core")
+    core.HomeAssistant = _Hass
+
+    def async_redact_data(value: Any, keys: set[str]) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: "<redacted>"
+                if key in keys
+                else async_redact_data(item, keys)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [async_redact_data(item, keys) for item in value]
+        return value
+
+    components = types.ModuleType("homeassistant.components")
+    components_diagnostics = types.ModuleType(
+        "homeassistant.components.diagnostics"
+    )
+    components_diagnostics.async_redact_data = async_redact_data
+
+    selector = types.ModuleType("homeassistant.helpers.selector")
+    selector.BooleanSelector = _Selector
+    selector.CountrySelector = _Selector
+    selector.NumberSelector = _Selector
+    selector.NumberSelectorConfig = _SelectorConfig
+    selector.NumberSelectorMode = types.SimpleNamespace(BOX="box")
+    selector.TextSelector = _Selector
+    selector.TextSelectorConfig = _SelectorConfig
+    selector.TextSelectorType = types.SimpleNamespace(TEXT="text", PASSWORD="password")
+
+    aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    aiohttp_client.async_get_clientsession = lambda _hass: None
+    helpers = types.ModuleType("homeassistant.helpers")
+    helpers.aiohttp_client = aiohttp_client
+    helpers.selector = selector
+    helpers_typing = types.ModuleType("homeassistant.helpers.typing")
+    helpers_typing.VolDictType = dict
+    helpers_storage = types.ModuleType("homeassistant.helpers.storage")
+    helpers_storage.Store = _Store
+
+    util = types.ModuleType("homeassistant.util")
+    util.slugify = lambda value: re.sub(r"[^a-z0-9]+", "_", value.lower()).strip(
+        "_"
+    )
+
+    modules = {
+        "homeassistant": homeassistant,
+        "homeassistant.components": components,
+        "homeassistant.components.diagnostics": components_diagnostics,
+        "homeassistant.config_entries": config_entries,
+        "homeassistant.const": const,
+        "homeassistant.core": core,
+        "homeassistant.helpers": helpers,
+        "homeassistant.helpers.aiohttp_client": aiohttp_client,
+        "homeassistant.helpers.selector": selector,
+        "homeassistant.helpers.storage": helpers_storage,
+        "homeassistant.helpers.typing": helpers_typing,
+        "homeassistant.util": util,
+    }
+    for name, module in modules.items():
+        sys.modules.setdefault(name, module)
+
+
+_install_homeassistant_stubs()
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [str(PACKAGE_PATH.parent)]
+sys.modules.setdefault("custom_components", custom_components)
+
+ecovacs_goat_g1 = types.ModuleType("custom_components.ecovacs_goat_g1")
+ecovacs_goat_g1.__path__ = [str(PACKAGE_PATH)]
+ecovacs_goat_g1.EcovacsConfigEntry = _ConfigEntry
+sys.modules.setdefault("custom_components.ecovacs_goat_g1", ecovacs_goat_g1)
+sys.modules["custom_components.ecovacs_goat_g1"].EcovacsConfigEntry = _ConfigEntry
+
+from custom_components.ecovacs_goat_g1 import config_flow
+from custom_components.ecovacs_goat_g1 import diagnostics as diagnostics_module
+from custom_components.ecovacs_goat_g1 import util as util_module
+from custom_components.ecovacs_goat_g1.const import (
+    CONF_DEVICE_ID,
+    CONF_SESSION_STORE_ID,
+    CONF_VERIFICATION_CODE,
+    DOMAIN,
+)
+from custom_components.ecovacs_goat_g1.mower_api import (
+    AccountSession,
+    EcovacsApiError,
+    EcovacsDeviceVerificationRequiredError,
+    EcovacsInvalidAuthError,
+)
+from custom_components.ecovacs_goat_g1.session_store import (
+    AccountSessionStore,
+    async_remove_account_session_store,
+)
+from custom_components.ecovacs_goat_g1.util import (
+    generate_client_device_id,
+    is_valid_client_device_id,
+    is_valid_session_store_id,
+    migrate_config_data,
+    migrate_client_device_id,
+)
+
+PERSISTED_STORE_ID = "0123456789abcdef0123456789abcdef"
+SENTINEL_SESSION = AccountSession(
+    "sentinel-user-id", "sentinel-access-token"
+)
+
+
+def _api() -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        account_session=SENTINEL_SESSION,
+        set_account_session_update_callback=MagicMock(),
+        request_device_verification_code=AsyncMock(),
+        verify_device=AsyncMock(),
+        get_devices=AsyncMock(return_value=[object()]),
+    )
+
+
+def _store() -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        async_load=AsyncMock(return_value=None),
+        async_save=AsyncMock(),
+        async_save_verified=AsyncMock(),
+    )
+
+
+def _new_flow() -> config_flow.EcovacsConfigFlow:
+    flow = config_flow.EcovacsConfigFlow()
+    flow.hass = _Hass()
+    return flow
+
+
+def test_setup_1013_requests_otp_and_persists_same_device_id() -> None:
+    """A setup challenge transitions to OTP without ever persisting the code."""
+    flow = _new_flow()
+    api = _api()
+    store = _store()
+    user_data = {
+        "name": "Garden GOAT",
+        "username": "owner@example.com",
+        "password": "password",
+        "country": "RO",
+    }
+
+    with (
+        patch.object(config_flow, "_create_api", return_value=(api, store)),
+        patch.object(
+            config_flow,
+            "_authenticate_and_find_devices",
+            AsyncMock(side_effect=EcovacsDeviceVerificationRequiredError()),
+        ),
+    ):
+        result = asyncio.run(flow.async_step_user(user_data))
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "device_verification"
+    api.request_device_verification_code.assert_awaited_once()
+    device_id = flow._verification_data[CONF_DEVICE_ID]
+    assert is_valid_client_device_id(device_id)
+    result = asyncio.run(
+        flow.async_step_device_verification({CONF_VERIFICATION_CODE: "123456"})
+    )
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_DEVICE_ID] == device_id
+    assert CONF_VERIFICATION_CODE not in result["data"]
+    api.verify_device.assert_awaited_once_with("123456")
+    api.get_devices.assert_awaited_once_with()
+    store.async_save.assert_awaited_once_with(None)
+    store.async_save_verified.assert_awaited_once_with(SENTINEL_SESSION)
+
+
+def test_reauth_sends_email_only_after_confirmation_and_reuses_stored_id() -> None:
+    """Repair is user-confirmed and keeps the already registered client id."""
+    persisted_id = "A1B2C3D4"
+    entry = _ConfigEntry(
+        {
+            "name": "Garden GOAT",
+            "username": "owner@example.com",
+            "password": "password",
+            "country": "RO",
+            CONF_DEVICE_ID: persisted_id,
+            CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+        }
+    )
+    flow = _new_flow()
+    flow._test_reauth_entry = entry
+    api = _api()
+    store = _store()
+
+    result = asyncio.run(flow.async_step_reauth(dict(entry.data)))
+    assert result["step_id"] == "reauth_confirm"
+    api.request_device_verification_code.assert_not_awaited()
+
+    with (
+        patch.object(
+            config_flow, "_create_api", return_value=(api, store)
+        ) as create_api,
+        patch.object(
+            config_flow,
+            "_authenticate_and_find_devices",
+            AsyncMock(side_effect=EcovacsDeviceVerificationRequiredError()),
+        ),
+    ):
+        result = asyncio.run(
+            flow.async_step_reauth_confirm({"password": "new-password"})
+        )
+
+    assert result["step_id"] == "device_verification"
+    assert create_api.call_args.args[1][CONF_DEVICE_ID] == persisted_id
+    assert create_api.call_args.args[1]["password"] == "new-password"
+    api.request_device_verification_code.assert_awaited_once()
+
+    result = asyncio.run(
+        flow.async_step_device_verification({CONF_VERIFICATION_CODE: "654321"})
+    )
+    assert result["reason"] == "reauth_successful"
+    assert result["data_updates"][CONF_DEVICE_ID] == persisted_id
+    assert result["data_updates"]["password"] == "new-password"
+    assert CONF_VERIFICATION_CODE not in result["data_updates"]
+    store.async_save.assert_awaited_once_with(None)
+    store.async_save_verified.assert_awaited_once_with(SENTINEL_SESSION)
+
+
+def test_reauth_changed_password_can_succeed_without_sending_otp() -> None:
+    """A corrected password is persisted when normal login now succeeds."""
+    entry = _ConfigEntry(
+        {
+            "name": "Garden GOAT",
+            "username": "owner@example.com",
+            "password": "old-password",
+            "country": "RO",
+            CONF_DEVICE_ID: "A1B2C3D4",
+            CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+        }
+    )
+    flow = _new_flow()
+    flow._test_reauth_entry = entry
+    api = _api()
+    store = _store()
+    asyncio.run(flow.async_step_reauth(dict(entry.data)))
+
+    with (
+        patch.object(config_flow, "_create_api", return_value=(api, store)),
+        patch.object(
+            config_flow,
+            "_authenticate_and_find_devices",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        result = asyncio.run(
+            flow.async_step_reauth_confirm({"password": "correct-password"})
+        )
+
+    assert result["reason"] == "reauth_successful"
+    assert result["data_updates"]["password"] == "correct-password"
+    assert result["data_updates"][CONF_DEVICE_ID] == "A1B2C3D4"
+    api.request_device_verification_code.assert_not_awaited()
+    store.async_save_verified.assert_awaited_once_with(SENTINEL_SESSION)
+
+
+def test_reauth_invalid_changed_password_stays_on_form() -> None:
+    """A bad replacement password is rejected without sending an email code."""
+    entry = _ConfigEntry(
+        {
+            "name": "Garden GOAT",
+            "username": "owner@example.com",
+            "password": "saved-password",
+            "country": "RO",
+            CONF_DEVICE_ID: "A1B2C3D4",
+            CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+        }
+    )
+    flow = _new_flow()
+    flow._test_reauth_entry = entry
+    api = _api()
+    store = _store()
+    asyncio.run(flow.async_step_reauth(dict(entry.data)))
+
+    with (
+        patch.object(config_flow, "_create_api", return_value=(api, store)),
+        patch.object(
+            config_flow,
+            "_authenticate_and_find_devices",
+            AsyncMock(side_effect=EcovacsInvalidAuthError()),
+        ),
+    ):
+        result = asyncio.run(
+            flow.async_step_reauth_confirm({"password": "wrong-password"})
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"]["base"] == "invalid_auth"
+    api.request_device_verification_code.assert_not_awaited()
+    store.async_save.assert_awaited_once_with(None)
+
+
+def test_verification_persists_session_before_mower_discovery() -> None:
+    """A consumed OTP is durable before downstream GOAT discovery begins."""
+    flow = _new_flow()
+    api = _api()
+    store = _store()
+    flow._verification_api = api
+    flow._verification_data = {
+        "name": "Garden GOAT",
+        "username": "owner@example.com",
+        "password": "password",
+        "country": "RO",
+        CONF_DEVICE_ID: "A1B2C3D4",
+        CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+    }
+    flow._verification_store = store
+
+    events: list[str] = []
+
+    async def verify(_code: str) -> None:
+        events.append("verify")
+        await store.async_save_verified(SENTINEL_SESSION)
+
+    async def discover() -> list[object]:
+        events.append("discover")
+        return [object()]
+
+    async def save(_session: AccountSession | None) -> None:
+        events.append("save")
+
+    api.verify_device.side_effect = verify
+    api.get_devices.side_effect = discover
+    store.async_save_verified.side_effect = save
+
+    result = asyncio.run(
+        flow.async_step_device_verification(
+            {CONF_VERIFICATION_CODE: "sentinel-otp"}
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert events == ["verify", "save", "discover", "save"]
+
+
+def test_transient_post_otp_failure_retries_without_resubmitting_otp() -> None:
+    """A durable verified session binds the entry without consuming a new OTP."""
+    flow = _new_flow()
+    api = _api()
+    store = _store()
+    api.get_devices.side_effect = EcovacsApiError("transient")
+    flow._verification_api = api
+    flow._verification_data = {
+        "name": "Garden GOAT",
+        "username": "owner@example.com",
+        "password": "password",
+        "country": "RO",
+        CONF_DEVICE_ID: "A1B2C3D4",
+        CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+    }
+    flow._verification_store = store
+
+    result = asyncio.run(
+        flow.async_step_device_verification(
+            {CONF_VERIFICATION_CODE: "sentinel-otp"}
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    api.verify_device.assert_awaited_once_with("sentinel-otp")
+    api.get_devices.assert_awaited_once_with()
+    store.async_save_verified.assert_awaited_once_with(SENTINEL_SESSION)
+
+
+def test_no_devices_removes_verified_session() -> None:
+    """An account without a GOAT cannot retain the just-verified raw session."""
+    flow = _new_flow()
+    api = _api()
+    store = _store()
+    api.get_devices.return_value = []
+
+    async def verify(_code: str) -> None:
+        await store.async_save_verified(SENTINEL_SESSION)
+
+    api.verify_device.side_effect = verify
+    flow._verification_api = api
+    flow._verification_data = {
+        "name": "Garden GOAT",
+        "username": "owner@example.com",
+        "password": "password",
+        "country": "RO",
+        CONF_DEVICE_ID: "A1B2C3D4",
+        CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+    }
+    flow._verification_store = store
+
+    result = asyncio.run(
+        flow.async_step_device_verification(
+            {CONF_VERIFICATION_CODE: "sentinel-otp"}
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "no_devices"
+    store.async_save_verified.assert_awaited_once_with(SENTINEL_SESSION)
+    store.async_save.assert_awaited_once_with(None)
+
+
+def test_create_api_persists_seeded_session_updates_privately() -> None:
+    """A loaded session persists rotations/clears until password fallback."""
+    data = {
+        "name": "Garden GOAT",
+        "username": "owner@example.com",
+        "password": "password",
+        "country": "RO",
+        CONF_DEVICE_ID: "A1B2C3D4",
+        CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+    }
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=SENTINEL_SESSION)
+    store.async_save = AsyncMock()
+    api = MagicMock()
+
+    with (
+        patch.object(
+            config_flow, "AccountSessionStore", return_value=store
+        ) as store_class,
+        patch.object(config_flow, "EcovacsMowerApi", return_value=api) as api_class,
+    ):
+        created_api, created_store = asyncio.run(
+            config_flow._create_api(_Hass(), data)
+        )
+
+    assert created_api is api
+    assert created_store is store
+    store_class.assert_called_once()
+    store_args = store_class.call_args.args
+    assert isinstance(store_args[0], _Hass)
+    assert store_args[1:] == (
+        PERSISTED_STORE_ID,
+        "A1B2C3D4",
+        "owner@example.com",
+        "RO",
+    )
+    assert api_class.call_args.kwargs["account_session"] == SENTINEL_SESSION
+    seeded_callback = api_class.call_args.kwargs[
+        "account_session_update_callback"
+    ]
+    assert seeded_callback is not None
+    rotated = AccountSession("sentinel-rotated-user", "sentinel-rotated-token")
+    replacement = AccountSession(
+        "sentinel-replacement-user", "sentinel-replacement-token"
+    )
+    asyncio.run(seeded_callback(rotated))
+    asyncio.run(seeded_callback(None))
+    asyncio.run(seeded_callback(replacement))
+    assert store.async_save.await_args_list == [call(rotated), call(None)]
+
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save.reset_mock()
+    with (
+        patch.object(config_flow, "AccountSessionStore", return_value=store),
+        patch.object(config_flow, "EcovacsMowerApi", return_value=api) as api_class,
+    ):
+        asyncio.run(config_flow._create_api(_Hass(), data))
+
+    assert api_class.call_args.kwargs["account_session"] is None
+    assert api_class.call_args.kwargs["account_session_update_callback"] is None
+
+
+def test_verified_session_persistence_uses_write_readback_boundary() -> None:
+    """OTP sessions use verified persistence while invalidation removes them."""
+    api = MagicMock()
+    store = _store()
+
+    config_flow._enable_verified_session_persistence(api, store)
+    callback = api.set_account_session_update_callback.call_args.args[0]
+    asyncio.run(callback(SENTINEL_SESSION))
+    asyncio.run(callback(None))
+
+    store.async_save_verified.assert_awaited_once_with(SENTINEL_SESSION)
+    store.async_save.assert_awaited_once_with(None)
+
+
+def test_private_store_is_atomic_private_and_device_bound() -> None:
+    """Raw material is private, atomic, and bound to account/country/device."""
+    session_store = AccountSessionStore(
+        _Hass(),
+        PERSISTED_STORE_ID,
+        "A1B2C3D4",
+        "owner@example.com",
+        "RO",
+    )
+    raw_store = session_store._store
+
+    assert raw_store.kwargs == {"private": True, "atomic_writes": True}
+    assert raw_store.key.endswith(f"auth_{PERSISTED_STORE_ID}")
+
+    asyncio.run(session_store.async_save(SENTINEL_SESSION))
+    assert raw_store.data["client_device_id"] == "A1B2C3D4"
+    assert raw_store.data["user_id"] == SENTINEL_SESSION.user_id
+    assert raw_store.data["access_token"] == SENTINEL_SESSION.access_token
+    assert re.fullmatch(r"[0-9a-f]{64}", raw_store.data["account_fingerprint"])
+    assert "owner@example.com" not in raw_store.data.values()
+    saved_data = dict(raw_store.data)
+    assert asyncio.run(session_store.async_load()) == SENTINEL_SESSION
+
+    asyncio.run(session_store.async_save_verified(SENTINEL_SESSION))
+    assert asyncio.run(session_store.async_load()) == SENTINEL_SESSION
+
+    for username, country, device_id in (
+        ("other@example.com", "RO", "A1B2C3D4"),
+        ("owner@example.com", "DE", "A1B2C3D4"),
+        ("owner@example.com", "RO", "Z9Y8X7W6"),
+    ):
+        mismatched = AccountSessionStore(
+            _Hass(),
+            PERSISTED_STORE_ID,
+            device_id,
+            username,
+            country,
+        )
+        mismatched._store.data = dict(saved_data)
+        assert asyncio.run(mismatched.async_load()) is None
+        assert mismatched._store.removed is True
+
+
+def test_private_store_ignores_malformed_partial_data_and_removes_cleanly() -> None:
+    """Partial credentials never become an AccountSession."""
+    session_store = AccountSessionStore(
+        _Hass(),
+        PERSISTED_STORE_ID,
+        "A1B2C3D4",
+        "owner@example.com",
+        "RO",
+    )
+    raw_store = session_store._store
+
+    for malformed in (
+        None,
+        [],
+        {},
+        {"client_device_id": "A1B2C3D4"},
+        {
+            "client_device_id": "A1B2C3D4",
+            "user_id": "sentinel-user-id",
+        },
+        {
+            "client_device_id": "A1B2C3D4",
+            "user_id": "",
+            "access_token": "sentinel-access-token",
+        },
+    ):
+        raw_store.data = malformed
+        assert asyncio.run(session_store.async_load()) is None
+
+    asyncio.run(session_store.async_save(None))
+    assert raw_store.removed is True
+    assert raw_store.data is None
+
+
+def test_remove_store_cleans_only_matching_corrupt_siblings(
+    tmp_path: Path,
+) -> None:
+    """Entry removal cleans validated remnants without broad filesystem scope."""
+    storage_dir = tmp_path / ".storage" / DOMAIN
+    storage_dir.mkdir(parents=True)
+    matching = [
+        storage_dir / f"auth_{PERSISTED_STORE_ID}.corrupt.2026-07-19",
+        storage_dir / f"auth_{PERSISTED_STORE_ID}.corrupt.second",
+    ]
+    for path in matching:
+        path.write_text("sentinel", encoding="utf-8")
+    unrelated = storage_dir / "auth_other.corrupt.2026-07-19"
+    unrelated.write_text("keep", encoding="utf-8")
+    matching_directory = (
+        storage_dir / f"auth_{PERSISTED_STORE_ID}.corrupt.directory"
+    )
+    matching_directory.mkdir()
+
+    hass = _Hass()
+    hass.config = types.SimpleNamespace(
+        path=lambda *parts: str(tmp_path.joinpath(*parts))
+    )
+    asyncio.run(
+        async_remove_account_session_store(hass, PERSISTED_STORE_ID)
+    )
+
+    assert all(not path.exists() for path in matching)
+    assert unrelated.read_text(encoding="utf-8") == "keep"
+    assert matching_directory.is_dir()
+
+
+def test_generated_client_device_id_has_vendor_format() -> None:
+    """Fresh ids are exactly eight uppercase ASCII letters or digits."""
+    generated = {generate_client_device_id() for _ in range(64)}
+
+    assert len(generated) > 1
+    assert all(re.fullmatch(r"[A-Z0-9]{8}", device_id) for device_id in generated)
+
+
+def test_migration_replaces_v1_and_v2_nonconforming_ids_once() -> None:
+    """Legacy and v2 ids are replaced once, then the replacement is stable."""
+    for old_device_id in (None, "HA-home", "HA-0123456789abcdef"):
+        original = {
+            "name": "Garden GOAT",
+            CONF_DEVICE_ID: old_device_id,
+        }
+        with patch.object(
+            util_module,
+            "generate_client_device_id",
+            return_value="Z9Y8X7W6",
+        ) as generate:
+            migrated = migrate_client_device_id(original)
+            migrated_again = migrate_client_device_id(migrated)
+
+        assert migrated[CONF_DEVICE_ID] == "Z9Y8X7W6"
+        assert migrated_again[CONF_DEVICE_ID] == "Z9Y8X7W6"
+        assert migrated["name"] == original["name"]
+        assert original[CONF_DEVICE_ID] == old_device_id
+        generate.assert_called_once_with()
+
+
+def test_migration_preserves_valid_client_device_id() -> None:
+    """A conforming persisted id survives migration and every reload."""
+    original = {
+        "name": "Garden GOAT",
+        CONF_DEVICE_ID: "A1B2C3D4",
+    }
+    with patch.object(util_module, "generate_client_device_id") as generate:
+        migrated = migrate_client_device_id(original)
+        migrated_again = migrate_client_device_id(migrated)
+
+    assert migrated[CONF_DEVICE_ID] == "A1B2C3D4"
+    assert migrated_again[CONF_DEVICE_ID] == "A1B2C3D4"
+    generate.assert_not_called()
+
+
+def test_v4_migration_adds_opaque_store_id_once_and_preserves_device_id() -> None:
+    """Migration adds only stable non-secret identifiers to config-entry data."""
+    original = {
+        "name": "Garden GOAT",
+        CONF_DEVICE_ID: "A1B2C3D4",
+    }
+
+    migrated = migrate_config_data(original)
+    migrated_again = migrate_config_data(migrated)
+
+    assert migrated[CONF_DEVICE_ID] == "A1B2C3D4"
+    assert is_valid_session_store_id(migrated[CONF_SESSION_STORE_ID])
+    assert migrated_again == migrated
+    assert CONF_SESSION_STORE_ID not in original
+    assert "access_token" not in migrated
+    assert "user_id" not in migrated
+
+
+def test_diagnostics_redact_config_and_device_identifiers() -> None:
+    """Diagnostics never expose credentials or private-store lookup material."""
+    entry = _ConfigEntry(
+        {
+            "name": "Sentinel GOAT",
+            "username": "sentinel-owner@example.com",
+            "password": "sentinel-password",
+            "country": "RO",
+            CONF_DEVICE_ID: "A1B2C3D4",
+            CONF_SESSION_STORE_ID: PERSISTED_STORE_ID,
+        },
+        title="Sentinel entry title",
+    )
+    entry.runtime_data = types.SimpleNamespace(
+        devices=[
+            {
+                "did": "sentinel-device-id",
+                "name": "Sentinel device name",
+                "homeId": "sentinel-home-id",
+            }
+        ],
+        coordinators=[],
+        debug_capture=types.SimpleNamespace(
+            summary=lambda: {"active": None},
+            recent_events=lambda *, limit: [
+                {"data": {"accessToken": "<redacted>"}, "limit": limit}
+            ],
+        ),
+    )
+
+    diagnostics = asyncio.run(
+        diagnostics_module.async_get_config_entry_diagnostics(_Hass(), entry)
+    )
+    rendered = json.dumps(diagnostics)
+
+    for sensitive in (
+        "sentinel-owner@example.com",
+        "sentinel-password",
+        "A1B2C3D4",
+        PERSISTED_STORE_ID,
+        "Sentinel entry title",
+        "sentinel-device-id",
+        "Sentinel device name",
+        "sentinel-home-id",
+    ):
+        assert sensitive not in rendered
+    assert rendered.count("<redacted>") >= 8

--- a/tests/ecovacs_goat_g1/test_entry_removal.py
+++ b/tests/ecovacs_goat_g1/test_entry_removal.py
@@ -1,0 +1,288 @@
+"""Tests for config-entry removal ordering."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+PACKAGE_PATH = Path(__file__).parents[2] / "custom_components" / "ecovacs_goat_g1"
+TEST_PACKAGE = "ecovacs_goat_g1_remove_test"
+CONTROLLER_PACKAGE = "ecovacs_goat_g1_controller_stop_test"
+
+
+class _GenericConfigEntry:
+    @classmethod
+    def __class_getitem__(cls, _item: Any) -> type[_GenericConfigEntry]:
+        return cls
+
+
+def _load_component_init(
+    remove_store: AsyncMock,
+) -> types.ModuleType:
+    """Load the integration entry points with narrow Home Assistant stubs."""
+    homeassistant = types.ModuleType("homeassistant")
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = _GenericConfigEntry
+
+    const = types.ModuleType("homeassistant.const")
+    const.ATTR_ENTITY_ID = "entity_id"
+    const.Platform = types.SimpleNamespace(
+        BUTTON="button",
+        LAWN_MOWER="lawn_mower",
+        NUMBER="number",
+        SELECT="select",
+        SENSOR="sensor",
+        SWITCH="switch",
+        TIME="time",
+    )
+
+    core = types.ModuleType("homeassistant.core")
+    core.HomeAssistant = object
+    core.ServiceCall = object
+    core.SupportsResponse = types.SimpleNamespace(ONLY="only")
+
+    exceptions = types.ModuleType("homeassistant.exceptions")
+    exceptions.HomeAssistantError = RuntimeError
+
+    config_validation = types.ModuleType(
+        "homeassistant.helpers.config_validation"
+    )
+    config_validation.entity_ids = lambda value: value
+    config_validation.string = lambda value: value
+    config_validation.boolean = lambda value: value
+    entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    helpers = types.ModuleType("homeassistant.helpers")
+    helpers.config_validation = config_validation
+    helpers.entity_registry = entity_registry
+
+    package_const = types.ModuleType(f"{TEST_PACKAGE}.const")
+    package_const.CONF_SESSION_STORE_ID = "session_store_id"
+    package_const.DOMAIN = "ecovacs_goat_g1"
+    for name in (
+        "SERVICE_CLEAR_DEBUG_CAPTURE",
+        "SERVICE_EXPORT_DEBUG_CAPTURE",
+        "SERVICE_MARK_DEBUG_CAPTURE",
+        "SERVICE_REFRESH_STATE",
+        "SERVICE_REQUEST_LIVE_POSITION_STREAM",
+        "SERVICE_START_DEBUG_CAPTURE",
+        "SERVICE_STOP_DEBUG_CAPTURE",
+    ):
+        setattr(package_const, name, name.lower())
+
+    package_controller = types.ModuleType(f"{TEST_PACKAGE}.controller")
+    package_controller.EcovacsController = type("EcovacsController", (), {})
+    package_frontend = types.ModuleType(f"{TEST_PACKAGE}.frontend")
+    package_frontend.async_register_frontend_card = AsyncMock()
+    package_session_store = types.ModuleType(f"{TEST_PACKAGE}.session_store")
+    package_session_store.async_remove_account_session_store = remove_store
+    package_util = types.ModuleType(f"{TEST_PACKAGE}.util")
+    package_util.migrate_config_data = lambda data: dict(data)
+
+    spec = importlib.util.spec_from_file_location(
+        TEST_PACKAGE,
+        PACKAGE_PATH / "__init__.py",
+        submodule_search_locations=[str(PACKAGE_PATH)],
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    modules = {
+        TEST_PACKAGE: module,
+        f"{TEST_PACKAGE}.const": package_const,
+        f"{TEST_PACKAGE}.controller": package_controller,
+        f"{TEST_PACKAGE}.frontend": package_frontend,
+        f"{TEST_PACKAGE}.session_store": package_session_store,
+        f"{TEST_PACKAGE}.util": package_util,
+        "homeassistant": homeassistant,
+        "homeassistant.config_entries": config_entries,
+        "homeassistant.const": const,
+        "homeassistant.core": core,
+        "homeassistant.exceptions": exceptions,
+        "homeassistant.helpers": helpers,
+        "homeassistant.helpers.config_validation": config_validation,
+        "homeassistant.helpers.entity_registry": entity_registry,
+    }
+    with patch.dict(sys.modules, modules):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_controller_module() -> types.ModuleType:
+    """Load the controller with narrow dependency stubs."""
+    parent = types.ModuleType(CONTROLLER_PACKAGE)
+    parent.__path__ = [str(PACKAGE_PATH)]
+
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = object
+    const = types.ModuleType("homeassistant.const")
+    const.CONF_COUNTRY = "country"
+    const.CONF_NAME = "name"
+    const.CONF_PASSWORD = "password"
+    const.CONF_USERNAME = "username"
+    core = types.ModuleType("homeassistant.core")
+    core.HomeAssistant = object
+    exceptions = types.ModuleType("homeassistant.exceptions")
+    exceptions.ConfigEntryAuthFailed = type(
+        "ConfigEntryAuthFailed", (RuntimeError,), {}
+    )
+    exceptions.ConfigEntryNotReady = type(
+        "ConfigEntryNotReady", (RuntimeError,), {}
+    )
+    aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    aiohttp_client.async_get_clientsession = lambda _hass: None
+    helpers = types.ModuleType("homeassistant.helpers")
+    helpers.aiohttp_client = aiohttp_client
+
+    package_const = types.ModuleType(f"{CONTROLLER_PACKAGE}.const")
+    for name, value in {
+        "DEFAULT_DEBUG_CAPTURE_MAX_DURATION_MINUTES": 30,
+        "DEFAULT_DEBUG_CAPTURE_MAX_SIZE_MB": 25,
+        "DEFAULT_DEBUG_CAPTURE_RAW_PAYLOADS": False,
+        "OPTION_DEBUG_CAPTURE_MAX_DURATION_MINUTES": "duration",
+        "OPTION_DEBUG_CAPTURE_MAX_SIZE_MB": "size",
+        "OPTION_DEBUG_CAPTURE_RAW_PAYLOADS": "raw",
+    }.items():
+        setattr(package_const, name, value)
+
+    package_debug = types.ModuleType(f"{CONTROLLER_PACKAGE}.debug_capture")
+    package_debug.DebugCaptureStore = type("DebugCaptureStore", (), {})
+    package_api = types.ModuleType(f"{CONTROLLER_PACKAGE}.mower_api")
+    package_api.AccountSession = type("AccountSession", (), {})
+    package_api.EcovacsAuthError = type("EcovacsAuthError", (RuntimeError,), {})
+    package_api.EcovacsDeviceVerificationRequiredError = type(
+        "EcovacsDeviceVerificationRequiredError",
+        (package_api.EcovacsAuthError,),
+        {},
+    )
+    package_api.EcovacsInvalidAuthError = type(
+        "EcovacsInvalidAuthError", (package_api.EcovacsAuthError,), {}
+    )
+    package_api.EcovacsMowerApi = type("EcovacsMowerApi", (), {})
+    package_coordinator = types.ModuleType(
+        f"{CONTROLLER_PACKAGE}.mower_coordinator"
+    )
+    package_coordinator.MowerCoordinator = type("MowerCoordinator", (), {})
+    package_store = types.ModuleType(f"{CONTROLLER_PACKAGE}.session_store")
+    package_store.AccountSessionStore = type("AccountSessionStore", (), {})
+    package_util = types.ModuleType(f"{CONTROLLER_PACKAGE}.util")
+    package_util.get_client_device_id = lambda _data: "A1B2C3D4"
+    package_util.get_session_store_id = (
+        lambda _data: "0123456789abcdef0123456789abcdef"
+    )
+
+    module_name = f"{CONTROLLER_PACKAGE}.controller"
+    spec = importlib.util.spec_from_file_location(
+        module_name, PACKAGE_PATH / "controller.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    modules = {
+        CONTROLLER_PACKAGE: parent,
+        module_name: module,
+        f"{CONTROLLER_PACKAGE}.const": package_const,
+        f"{CONTROLLER_PACKAGE}.debug_capture": package_debug,
+        f"{CONTROLLER_PACKAGE}.mower_api": package_api,
+        f"{CONTROLLER_PACKAGE}.mower_coordinator": package_coordinator,
+        f"{CONTROLLER_PACKAGE}.session_store": package_store,
+        f"{CONTROLLER_PACKAGE}.util": package_util,
+        "homeassistant.config_entries": config_entries,
+        "homeassistant.const": const,
+        "homeassistant.core": core,
+        "homeassistant.exceptions": exceptions,
+        "homeassistant.helpers": helpers,
+        "homeassistant.helpers.aiohttp_client": aiohttp_client,
+    }
+    with patch.dict(sys.modules, modules):
+        spec.loader.exec_module(module)
+    return module
+
+
+def test_remove_entry_tears_down_before_store_deletion_idempotently() -> None:
+    """Late callbacks are tombstoned before private session data is deleted."""
+    events: list[str] = []
+    controller = types.SimpleNamespace(
+        teardown=AsyncMock(side_effect=lambda: events.append("teardown"))
+    )
+    remove_store = AsyncMock(side_effect=lambda *_args: events.append("remove"))
+    component = _load_component_init(remove_store)
+    entry = types.SimpleNamespace(
+        data={"session_store_id": "0123456789abcdef0123456789abcdef"},
+        runtime_data=controller,
+    )
+    hass = object()
+
+    asyncio.run(component.async_remove_entry(hass, entry))
+    asyncio.run(component.async_remove_entry(hass, entry))
+
+    assert events == ["teardown", "remove", "teardown", "remove"]
+    assert controller.teardown.await_count == 2
+    assert remove_store.await_count == 2
+
+
+def test_remove_entry_without_runtime_still_deletes_store() -> None:
+    """A never-loaded legacy entry can be removed without controller state."""
+    remove_store = AsyncMock()
+    component = _load_component_init(remove_store)
+    entry = types.SimpleNamespace(
+        data={"session_store_id": "0123456789abcdef0123456789abcdef"}
+    )
+    hass = object()
+
+    asyncio.run(component.async_remove_entry(hass, entry))
+
+    remove_store.assert_awaited_once_with(
+        hass, "0123456789abcdef0123456789abcdef"
+    )
+
+
+def test_remove_entry_deletes_store_even_when_teardown_fails() -> None:
+    """The private credential file is removed unconditionally."""
+    events: list[str] = []
+
+    async def fail_teardown() -> None:
+        events.append("teardown")
+        raise RuntimeError("sentinel teardown failure")
+
+    controller = types.SimpleNamespace(teardown=AsyncMock(side_effect=fail_teardown))
+    remove_store = AsyncMock(side_effect=lambda *_args: events.append("remove"))
+    component = _load_component_init(remove_store)
+    entry = types.SimpleNamespace(
+        data={"session_store_id": "0123456789abcdef0123456789abcdef"},
+        runtime_data=controller,
+    )
+
+    async def run() -> None:
+        try:
+            await component.async_remove_entry(object(), entry)
+        except RuntimeError as err:
+            assert str(err) == "sentinel teardown failure"
+        else:
+            raise AssertionError("teardown failure was swallowed")
+
+    asyncio.run(run())
+
+    assert events == ["teardown", "remove"]
+    remove_store.assert_awaited_once()
+
+
+def test_stop_coordinators_is_best_effort() -> None:
+    """One failing coordinator cannot prevent the others from stopping."""
+    component = _load_controller_module()
+    controller = component.EcovacsController.__new__(
+        component.EcovacsController
+    )
+    failing = types.SimpleNamespace(
+        async_stop=AsyncMock(side_effect=RuntimeError("sentinel stop failure"))
+    )
+    succeeding = types.SimpleNamespace(async_stop=AsyncMock())
+
+    with patch.object(component._LOGGER, "warning") as warning:
+        asyncio.run(controller._stop_coordinators([failing, succeeding]))
+
+    failing.async_stop.assert_awaited_once_with()
+    succeeding.async_stop.assert_awaited_once_with()
+    warning.assert_called_once()

--- a/tests/ecovacs_goat_g1/test_mower_api_verification.py
+++ b/tests/ecovacs_goat_g1/test_mower_api_verification.py
@@ -1,0 +1,721 @@
+"""Tests for ECOVACS client-device verification."""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+import sys
+import time
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, call
+
+from aiohttp import ClientError
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+PACKAGE_PATH = Path(__file__).parents[2] / "custom_components" / "ecovacs_goat_g1"
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [str(PACKAGE_PATH.parent)]
+sys.modules.setdefault("custom_components", custom_components)
+
+ecovacs_goat_g1 = types.ModuleType("custom_components.ecovacs_goat_g1")
+ecovacs_goat_g1.__path__ = [str(PACKAGE_PATH)]
+sys.modules.setdefault("custom_components.ecovacs_goat_g1", ecovacs_goat_g1)
+
+from custom_components.ecovacs_goat_g1.mower_api import (
+    AccountSession,
+    Credentials,
+    EcovacsApiError,
+    EcovacsDeviceVerificationRequiredError,
+    EcovacsInvalidAuthError,
+    EcovacsInvalidVerificationCodeError,
+    EcovacsMowerApi,
+    PUBLIC_KEY_CONFIG,
+)
+from custom_components.ecovacs_goat_g1.debug_capture import DebugCaptureStore
+
+ACCOUNT = "test@example.com"
+DEVICE_ID = "A1B2C3D4"
+
+
+def _mock_response(payload: Any) -> Any:
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.json = AsyncMock(return_value=payload)
+    context_manager = MagicMock()
+    context_manager.__aenter__ = AsyncMock(return_value=response)
+    context_manager.__aexit__ = AsyncMock(return_value=None)
+    return context_manager
+
+
+def _api(
+    session: MagicMock,
+    *,
+    account_session: AccountSession | None = None,
+    account_session_update_callback: AsyncMock | None = None,
+) -> EcovacsMowerApi:
+    return EcovacsMowerApi(
+        session,
+        username=ACCOUNT,
+        password="password",
+        country="RO",
+        device_id=DEVICE_ID,
+        account_session=account_session,
+        account_session_update_callback=account_session_update_callback,
+    )
+
+
+def _public_key_response(private_key: rsa.RSAPrivateKey) -> dict[str, Any]:
+    encoded_key = base64.b64encode(
+        private_key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    ).decode()
+    return {
+        "code": "0000",
+        "data": [
+            {
+                "key": PUBLIC_KEY_CONFIG,
+                "value": f'{{"publicKey":"{encoded_key}"}}',
+            }
+        ],
+    }
+
+
+def _decrypt(
+    private_key: rsa.RSAPrivateKey, params: dict[str, Any], field: str
+) -> str:
+    return private_key.decrypt(
+        base64.b64decode(params[field]), padding.PKCS1v15()
+    ).decode()
+
+
+def test_login_raises_typed_device_verification_error() -> None:
+    """Code 1013 must start verification instead of reporting a bad password."""
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        {
+            "code": "1013",
+            "msg": "Please update to the latest version to continue.",
+            "data": None,
+        }
+    )
+
+    async def run() -> None:
+        try:
+            await _api(session).authenticate()
+        except EcovacsDeviceVerificationRequiredError:
+            pass
+        else:
+            raise AssertionError("code 1013 did not raise the typed error")
+
+    asyncio.run(run())
+    url = session.get.call_args.args[0]
+    assert f"/{DEVICE_ID}/global_e/1.6.3/google_play/1/user/login" in url
+
+
+def test_request_code_encrypts_email_and_uses_verification_api() -> None:
+    """The email is RSA encrypted and the stable id signs every request."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    session = MagicMock()
+    session.get.side_effect = [
+        _mock_response(_public_key_response(private_key)),
+        _mock_response({"code": "0000", "data": {"verifyId": "verify-id"}}),
+    ]
+
+    asyncio.run(_api(session).request_device_verification_code())
+
+    public_key_call, send_code_call = session.get.call_args_list
+    expected_base = f"/v1/private/ro/EN/{DEVICE_ID}/global_e/3.14.0/google_play/1"
+    assert public_key_call.args[0].endswith(
+        f"{expected_base}/common/getConfig"
+    )
+    assert send_code_call.args[0].endswith(
+        f"{expected_base}/user/sendEmailVerifyCode"
+    )
+    send_params = send_code_call.kwargs["params"]
+    assert _decrypt(private_key, send_params, "encryptEmail") == ACCOUNT
+    assert send_params["verifyType"] == "EMAIL_VERIFY_DEVICE"
+    assert send_params["supportChar"] == "N"
+    assert send_params["isForce"] == "N"
+    assert send_params["authAppkey"] == "1520391301804"
+    assert send_params["authSign"]
+
+
+def test_verify_device_completes_login_and_caches_credentials() -> None:
+    """A valid OTP verifies the same id and yields reusable credentials."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    session = MagicMock()
+    session.get.side_effect = [
+        _mock_response(_public_key_response(private_key)),
+        _mock_response({"code": "0000", "data": {"verifyId": "verify-id"}}),
+        _mock_response(
+            {
+                "code": "0000",
+                "data": {"uid": "user-id", "accessToken": "access-token"},
+            }
+        ),
+        _mock_response({"code": "0000", "data": {"authCode": "auth-code"}}),
+    ]
+    session.post.return_value = _mock_response(
+        {
+            "result": "ok",
+            "userId": "user-id",
+            "token": "portal-token",
+            "last": 604800000,
+        }
+    )
+    api = _api(session)
+
+    async def run() -> None:
+        await api.request_device_verification_code()
+        credentials = await api.verify_device(" 123456 ")
+        assert credentials.token == "portal-token"
+        assert credentials.user_id == "user-id"
+        assert credentials.expires_at > time.time()
+        assert await api.authenticate() == credentials
+
+    asyncio.run(run())
+
+    verify_call = session.get.call_args_list[2]
+    verify_params = verify_call.kwargs["params"]
+    assert _decrypt(private_key, verify_params, "encryptAccount") == ACCOUNT
+    assert verify_params["verifyCode"] == "123456"
+    assert verify_params["model"] == "Pixel 7"
+    assert verify_params["system"] == "Android 14"
+
+    portal_call = session.post.call_args
+    assert portal_call.kwargs["json"]["resource"] == DEVICE_ID
+    assert portal_call.kwargs["json"]["token"] == "auth-code"
+    assert session.get.call_count == 4
+
+
+def test_fresh_api_reuses_persisted_session_and_gets_devices_without_password() -> None:
+    """A process restart can reach GOAT discovery without password login."""
+    persisted = AccountSession(
+        user_id="sentinel-old-user",
+        access_token="sentinel-old-access-token",
+    )
+    rotated = AccountSession(
+        user_id="sentinel-rotated-user",
+        access_token="sentinel-rotated-access-token",
+    )
+    session = MagicMock()
+    session.get.side_effect = [
+        _mock_response(
+            {
+                "code": "0000",
+                "data": {
+                    "uid": rotated.user_id,
+                    "accessToken": rotated.access_token,
+                },
+            }
+        ),
+        _mock_response(
+            {"code": "0000", "data": {"authCode": "sentinel-auth-code"}}
+        ),
+    ]
+    session.post.side_effect = [
+        _mock_response(
+            {
+                "result": "ok",
+                "userId": rotated.user_id,
+                "token": "sentinel-portal-token",
+                "last": 604800000,
+            }
+        ),
+        _mock_response(
+            {
+                "devices": [
+                    {
+                        "did": "sentinel-did",
+                        "class": "sentinel-class",
+                        "resource": "sentinel-resource",
+                        "name": "Sentinel GOAT",
+                        "company": "eco-ng",
+                    }
+                ]
+            }
+        ),
+        _mock_response({"devices": []}),
+    ]
+    callback = AsyncMock()
+    api = _api(
+        session,
+        account_session=persisted,
+        account_session_update_callback=callback,
+    )
+
+    devices = asyncio.run(api.get_devices())
+
+    assert [device.did for device in devices] == ["sentinel-did"]
+    assert api.account_session == rotated
+    callback.assert_awaited_once_with(rotated)
+    requested_urls = [item.args[0] for item in session.get.call_args_list]
+    assert any("/v2/private/" in url and url.endswith("/user/checkLogin") for url in requested_urls)
+    assert all(not url.endswith("/user/login") for url in requested_urls)
+    check_login_params = session.get.call_args_list[0].kwargs["params"]
+    assert check_login_params["uid"] == persisted.user_id
+    assert check_login_params["accessToken"] == persisted.access_token
+
+
+def test_rotated_session_is_persisted_before_portal_exchange() -> None:
+    """checkLogin rotation reaches the persistence callback immediately."""
+    old_session = AccountSession("sentinel-old-user", "sentinel-old-token")
+    rotated_session = AccountSession(
+        "sentinel-rotated-user", "sentinel-rotated-token"
+    )
+    callback = AsyncMock()
+    api = _api(
+        MagicMock(),
+        account_session=old_session,
+        account_session_update_callback=callback,
+    )
+    api._check_login = AsyncMock(return_value=rotated_session)
+    api._complete_login = AsyncMock(
+        return_value=Credentials(
+            user_id=rotated_session.user_id,
+            token="sentinel-portal-token",
+            expires_at=time.time() + 3600,
+        )
+    )
+    api._login_password = AsyncMock()
+
+    credentials = asyncio.run(api.authenticate())
+
+    assert credentials.user_id == rotated_session.user_id
+    callback.assert_awaited_once_with(rotated_session)
+    api._complete_login.assert_awaited_once_with(
+        rotated_session.user_id, rotated_session.access_token
+    )
+    api._login_password.assert_not_awaited()
+
+
+def test_invalid_saved_session_falls_back_once_and_replaces_it() -> None:
+    """Only a typed invalid session permits one password fallback."""
+    old_session = AccountSession("sentinel-old-user", "sentinel-old-token")
+    replacement = AccountSession(
+        "sentinel-replacement-user", "sentinel-replacement-token"
+    )
+    callback = AsyncMock()
+    api = _api(
+        MagicMock(),
+        account_session=old_session,
+        account_session_update_callback=callback,
+    )
+    api._check_login = AsyncMock(side_effect=EcovacsInvalidAuthError())
+    api._login_password = AsyncMock(
+        return_value={
+            "uid": replacement.user_id,
+            "accessToken": replacement.access_token,
+        }
+    )
+    api._complete_login = AsyncMock(
+        return_value=Credentials(
+            user_id=replacement.user_id,
+            token="sentinel-portal-token",
+            expires_at=time.time() + 3600,
+        )
+    )
+
+    asyncio.run(api.authenticate())
+
+    assert callback.await_args_list == [call(None), call(replacement)]
+    api._login_password.assert_awaited_once_with()
+    assert api.account_session == replacement
+
+
+def test_invalid_saved_session_then_1013_stays_cleared() -> None:
+    """A definitively invalid session is not restored after password challenge."""
+    old_session = AccountSession("sentinel-old-user", "sentinel-old-token")
+    callback = AsyncMock()
+    api = _api(
+        MagicMock(),
+        account_session=old_session,
+        account_session_update_callback=callback,
+    )
+    api._check_login = AsyncMock(side_effect=EcovacsInvalidAuthError())
+    api._login_password = AsyncMock(
+        side_effect=EcovacsDeviceVerificationRequiredError()
+    )
+
+    async def run() -> None:
+        try:
+            await api.authenticate()
+        except EcovacsDeviceVerificationRequiredError:
+            pass
+        else:
+            raise AssertionError("password challenge was accepted")
+
+    asyncio.run(run())
+
+    callback.assert_awaited_once_with(None)
+    assert api.account_session is None
+    api._login_password.assert_awaited_once_with()
+
+
+def test_definitive_password_portal_failure_clears_early_raw_session() -> None:
+    """Typed invalid/1013 portal failures cannot leave an unusable raw session."""
+    acquired = AccountSession("sentinel-user", "sentinel-access-token")
+
+    for failure in (
+        EcovacsInvalidAuthError(),
+        EcovacsDeviceVerificationRequiredError(),
+    ):
+        callback = AsyncMock()
+        api = _api(
+            MagicMock(), account_session_update_callback=callback
+        )
+        api._login_password = AsyncMock(
+            return_value={
+                "uid": acquired.user_id,
+                "accessToken": acquired.access_token,
+            }
+        )
+        api._complete_login = AsyncMock(side_effect=failure)
+
+        async def run() -> None:
+            try:
+                await api.authenticate()
+            except type(failure):
+                pass
+            else:
+                raise AssertionError("definitive portal failure was accepted")
+
+        asyncio.run(run())
+
+        assert callback.await_args_list == [call(acquired), call(None)]
+        assert api.account_session is None
+
+
+def test_transient_password_portal_failure_retains_early_raw_session() -> None:
+    """A retryable portal outage keeps the password-acquired raw session."""
+    acquired = AccountSession("sentinel-user", "sentinel-access-token")
+    callback = AsyncMock()
+    api = _api(MagicMock(), account_session_update_callback=callback)
+    api._login_password = AsyncMock(
+        return_value={
+            "uid": acquired.user_id,
+            "accessToken": acquired.access_token,
+        }
+    )
+    api._complete_login = AsyncMock(side_effect=EcovacsApiError("transient"))
+
+    async def run() -> None:
+        try:
+            await api.authenticate()
+        except EcovacsApiError:
+            pass
+        else:
+            raise AssertionError("transient portal failure was accepted")
+
+    asyncio.run(run())
+
+    callback.assert_awaited_once_with(acquired)
+    assert api.account_session == acquired
+
+
+def test_transient_saved_session_failure_never_falls_back_to_password() -> None:
+    """Transport/server failures retain the raw session and avoid password auth."""
+    persisted = AccountSession("sentinel-user", "sentinel-access-token")
+    callback = AsyncMock()
+    api = _api(
+        MagicMock(),
+        account_session=persisted,
+        account_session_update_callback=callback,
+    )
+    api._check_login = AsyncMock(side_effect=EcovacsApiError("transient"))
+    api._login_password = AsyncMock()
+
+    async def run() -> None:
+        try:
+            await api.authenticate()
+        except EcovacsApiError:
+            pass
+        else:
+            raise AssertionError("transient failure was accepted")
+
+    asyncio.run(run())
+
+    assert api.account_session == persisted
+    callback.assert_not_awaited()
+    api._login_password.assert_not_awaited()
+
+
+def test_rotated_session_survives_transient_portal_exchange_failure() -> None:
+    """A rotated raw session remains usable when the portal is temporarily down."""
+    persisted = AccountSession("sentinel-old-user", "sentinel-old-token")
+    rotated = AccountSession("sentinel-new-user", "sentinel-new-token")
+    callback = AsyncMock()
+    api = _api(
+        MagicMock(),
+        account_session=persisted,
+        account_session_update_callback=callback,
+    )
+    api._check_login = AsyncMock(return_value=rotated)
+    api._complete_login = AsyncMock(side_effect=EcovacsApiError("transient"))
+    api._login_password = AsyncMock()
+
+    async def run() -> None:
+        try:
+            await api.authenticate()
+        except EcovacsApiError:
+            pass
+        else:
+            raise AssertionError("transient portal failure was accepted")
+
+    asyncio.run(run())
+
+    assert api.account_session == rotated
+    callback.assert_awaited_once_with(rotated)
+    api._login_password.assert_not_awaited()
+
+
+def test_force_refresh_reuses_raw_session_without_password() -> None:
+    """Runtime expiry/force refresh exchanges the saved raw session again."""
+    persisted = AccountSession("sentinel-user", "sentinel-access-token")
+    api = _api(MagicMock(), account_session=persisted)
+    api._check_login = AsyncMock(return_value=persisted)
+    api._complete_login = AsyncMock(
+        side_effect=[
+            Credentials("sentinel-user", "sentinel-portal-one", time.time() + 3600),
+            Credentials("sentinel-user", "sentinel-portal-two", time.time() + 3600),
+        ]
+    )
+    api._login_password = AsyncMock()
+
+    first = asyncio.run(api.authenticate())
+    cached = asyncio.run(api.authenticate())
+    refreshed = asyncio.run(api.authenticate(force=True))
+
+    assert cached is first
+    assert refreshed.token == "sentinel-portal-two"
+    assert api._check_login.await_count == 2
+    assert api._complete_login.await_count == 2
+    api._login_password.assert_not_awaited()
+
+
+def test_verify_device_persists_session_before_portal_exchange() -> None:
+    """A consumed OTP remains recoverable if the portal is temporarily down."""
+    verified = AccountSession("sentinel-user", "sentinel-access-token")
+    callback = AsyncMock()
+    api = _api(MagicMock(), account_session_update_callback=callback)
+    api._encrypt_account = AsyncMock(return_value="sentinel-encrypted-account")
+    api._call_private_api = AsyncMock(
+        return_value={
+            "uid": verified.user_id,
+            "accessToken": verified.access_token,
+        }
+    )
+    api._complete_login = AsyncMock(side_effect=EcovacsApiError("transient"))
+
+    async def fail_once() -> None:
+        try:
+            await api.verify_device("sentinel-otp")
+        except EcovacsApiError:
+            pass
+        else:
+            raise AssertionError("failed portal exchange was accepted")
+
+    asyncio.run(fail_once())
+    assert api.account_session == verified
+    callback.assert_awaited_once_with(verified)
+
+    credentials = Credentials(
+        "sentinel-user", "sentinel-portal-token", time.time() + 3600
+    )
+    api._check_login = AsyncMock(return_value=verified)
+    api._complete_login = AsyncMock(return_value=credentials)
+    assert asyncio.run(api.authenticate()) == credentials
+    assert api.account_session == verified
+    assert callback.await_args_list == [call(verified), call(verified)]
+
+
+def test_definitive_verify_portal_failure_clears_verified_session() -> None:
+    """Typed invalid/1013 exchange responses invalidate verifyDevice output."""
+    verified = AccountSession("sentinel-user", "sentinel-access-token")
+
+    for failure in (
+        EcovacsInvalidAuthError(),
+        EcovacsDeviceVerificationRequiredError(),
+    ):
+        callback = AsyncMock()
+        api = _api(
+            MagicMock(), account_session_update_callback=callback
+        )
+        api._encrypt_account = AsyncMock(
+            return_value="sentinel-encrypted-account"
+        )
+        api._call_private_api = AsyncMock(
+            return_value={
+                "uid": verified.user_id,
+                "accessToken": verified.access_token,
+            }
+        )
+        api._complete_login = AsyncMock(side_effect=failure)
+
+        async def run() -> None:
+            try:
+                await api.verify_device("sentinel-otp")
+            except type(failure):
+                pass
+            else:
+                raise AssertionError("definitive verify failure was accepted")
+
+        asyncio.run(run())
+
+        assert callback.await_args_list == [call(verified), call(None)]
+        assert api.account_session is None
+
+
+def test_account_session_repr_never_contains_raw_values() -> None:
+    """Accidental logging of the value object cannot disclose its fields."""
+    session = AccountSession("sentinel-user-id", "sentinel-access-token")
+
+    rendered = repr(session)
+
+    assert "sentinel-user-id" not in rendered
+    assert "sentinel-access-token" not in rendered
+
+
+def test_debug_capture_redacts_session_keys_values_and_manifest(
+    tmp_path: Path,
+) -> None:
+    """Neither JSONL nor exported manifest metadata may disclose a session."""
+    user_id = "sentinel-private-user-id"
+    access_token = "sentinel-private-access-token"
+    capture = DebugCaptureStore(
+        tmp_path / "captures",
+        tmp_path / "exports",
+    )
+    capture.add_redaction_value(user_id)
+    capture.add_redaction_value(access_token)
+
+    capture.start(
+        reason=f"diagnose {access_token}",
+        include_raw_payloads=True,
+    )
+    capture.capture_event(
+        "auth_probe",
+        {
+            "uid": user_id,
+            "accessToken": access_token,
+            "nested": {
+                "message": f"user={user_id}; token={access_token}",
+            },
+        },
+    )
+    capture.stop()
+
+    session_path = next((tmp_path / "captures").iterdir())
+    persisted = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(session_path.iterdir())
+        if path.is_file()
+    )
+    assert user_id not in persisted
+    assert access_token not in persisted
+    assert "<redacted>" in persisted
+
+
+def test_debug_capture_key_redaction_is_recursive(tmp_path: Path) -> None:
+    """Known raw-session key spellings are redacted at every nesting level."""
+    capture = DebugCaptureStore(
+        tmp_path / "captures",
+        tmp_path / "exports",
+    )
+    capture.start(include_raw_payloads=True)
+    capture.capture_event(
+        "auth_probe",
+        {
+            "outer": [
+                {
+                    "access_token": "sentinel-access-token",
+                    "user_id": "sentinel-user-id",
+                }
+            ]
+        },
+    )
+    capture.stop()
+
+    rendered = json.dumps(capture.recent_events())
+    assert "sentinel-access-token" not in rendered
+    assert "sentinel-user-id" not in rendered
+    assert rendered.count("<redacted>") >= 2
+
+
+def test_invalid_verification_code_is_typed_and_not_logged_in_error() -> None:
+    """Code 1012 stays distinct and the exception never echoes the OTP."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    session = MagicMock()
+    session.get.side_effect = [
+        _mock_response(_public_key_response(private_key)),
+        _mock_response(
+            {
+                "code": "1012",
+                "msg": "Incorrect verification code.",
+                "data": None,
+            }
+        ),
+    ]
+
+    async def run() -> None:
+        try:
+            await _api(session).verify_device("secret-otp")
+        except EcovacsInvalidVerificationCodeError as err:
+            assert "secret-otp" not in str(err)
+        else:
+            raise AssertionError("code 1012 did not raise the typed error")
+
+    asyncio.run(run())
+
+
+def test_unknown_auth_error_does_not_echo_response_data() -> None:
+    """Access tokens in error payloads are never copied into exceptions."""
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        {
+            "code": "9999",
+            "msg": "Request rejected",
+            "data": {"accessToken": "must-not-leak"},
+        }
+    )
+
+    async def run() -> None:
+        try:
+            await _api(session).authenticate()
+        except EcovacsApiError as err:
+            assert "must-not-leak" not in str(err)
+        else:
+            raise AssertionError("unknown auth failure was accepted")
+
+    asyncio.run(run())
+
+
+def test_transport_error_suppresses_sensitive_request_context() -> None:
+    """A logged transport failure cannot reveal query-string OTPs or tokens."""
+    session = MagicMock()
+    context_manager = MagicMock()
+    context_manager.__aenter__ = AsyncMock(
+        side_effect=ClientError("https://example.test/?verifyCode=secret-otp")
+    )
+    context_manager.__aexit__ = AsyncMock(return_value=None)
+    session.get.return_value = context_manager
+
+    async def run() -> None:
+        try:
+            await _api(session).verify_device("secret-otp")
+        except EcovacsApiError as err:
+            assert "secret-otp" not in str(err)
+            assert err.__suppress_context__ is True
+        else:
+            raise AssertionError("transport failure was accepted")
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Fix ECOVACS login failures that return code `1013` by implementing the official client-device verification flow.

This change:

- generates and persists a stable ECOVACS-compatible client device ID
- requests and validates the emailed one-time verification code
- reuses and rotates the resulting account session through signed v2 `checkLogin`
- supports reauthentication without repeatedly consuming OTPs
- distinguishes invalid credentials, invalid OTPs, verification challenges, and transient failures

## Session security

Reusable ECOVACS account sessions are stored separately from config entries in a private, atomic Home Assistant store.

- OTP values are never persisted
- account tokens are excluded from config entries and diagnostics
- stored sessions are bound to the configured account, country, and client device ID
- writes used across the OTP boundary are verified by readback
- malformed, misbound, and corrupt session data is removed
- entry deletion drains pending writes and removes private session files
- debug captures redact account-session identifiers and tokens

The private store uses operating-system access control (`0600`); it is not encryption against Home Assistant itself or a host administrator. Users should protect the host and use encrypted backups.

## Compatibility

Existing entries migrate to config-entry version 4 and receive stable device and private-store identifiers. The current `develop` frontend registration ordering and release versioning remain unchanged.

## Validation

- 100 tests passed
- Python bytecode compilation passed
- targeted Ruff lint passed
- whitespace/diff validation passed
- validated on Home Assistant 2026.7.2 with a real verification challenge:
  - OTP accepted once
  - entry loaded successfully after config-entry reload and full restart
  - no repeated `1013`
  - no unavailable entities or repair issues
  - private store permissions verified as `0600`
  - no token or OTP fields present in the config entry

## Known limitation

A hard process termination in the very short interval between persisting a successful OTP session and creating the config entry can leave an unreferenced mode-`0600` store. Normal exception paths bind or clean the store; automatic startup garbage collection was avoided because it could race an active verification flow.

Closes #8.
