### PR TITLE
Add ECOVACS device-verification (email code) login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ You need your ECOVACS account username, password, and country. The integration u
 
 During setup, choose a Home Assistant device name. A generated default such as `Ecovacs-GOAT-1` is provided.
 
+If ECOVACS has not seen this Home Assistant device before, it may require one-time email
+verification: after entering your credentials you'll be asked for a code emailed to your account.
+Enter it to finish setup — verification is tied to this integration's device id (derived from your
+Home Assistant instance name), so it should not be required again on future logins from the same
+instance.
+
 ## Optional Dashboard Card
 
 The custom card is optional, but recommended. It exposes a clear stop button and a mower-focused map layout.

--- a/custom_components/ecovacs_goat_g1/config_flow.py
+++ b/custom_components/ecovacs_goat_g1/config_flow.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_COUNTRY, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, selector
 from homeassistant.helpers.typing import VolDictType
 
@@ -23,53 +22,29 @@ from .const import (
     OPTION_DEBUG_CAPTURE_MAX_SIZE_MB,
     OPTION_DEBUG_CAPTURE_RAW_PAYLOADS,
 )
-from .mower_api import EcovacsApiError, EcovacsAuthError, EcovacsMowerApi
+from .mower_api import (
+    EcovacsApiError,
+    EcovacsAuthError,
+    EcovacsDeviceVerificationRequiredError,
+    EcovacsInvalidVerificationCodeError,
+    EcovacsMowerApi,
+)
 from .util import get_client_device_id
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME_PREFIX = "Ecovacs-GOAT"
-
-
-async def _validate_input(
-    hass: HomeAssistant, user_input: dict[str, Any]
-) -> dict[str, str]:
-    """Validate user input."""
-    errors: dict[str, str] = {}
-    if not str(user_input.get(CONF_NAME, "")).strip():
-        errors[CONF_NAME] = "invalid_name"
-        return errors
-
-    device_id = get_client_device_id(hass)
-    api = EcovacsMowerApi(
-        aiohttp_client.async_get_clientsession(hass),
-        username=user_input[CONF_USERNAME],
-        password=user_input[CONF_PASSWORD],
-        country=user_input[CONF_COUNTRY],
-        device_id=device_id,
-    )
-
-    try:
-        await api.authenticate()
-        devices = await api.get_devices()
-    except EcovacsAuthError:
-        errors["base"] = "invalid_auth"
-    except (ClientError, EcovacsApiError):
-        _LOGGER.debug("Cannot connect", exc_info=True)
-        errors["base"] = "cannot_connect"
-    except Exception:
-        _LOGGER.exception("Unexpected exception during login")
-        errors["base"] = "unknown"
-
-    if not errors and not devices:
-        errors["base"] = "unknown"
-
-    return errors
+CONF_VERIFICATION_CODE = "verification_code"
 
 
 class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ecovacs."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._user_input: dict[str, Any] | None = None
+        self._api: EcovacsMowerApi | None = None
 
     @staticmethod
     def async_get_options_flow(config_entry: ConfigEntry) -> EcovacsOptionsFlow:
@@ -80,7 +55,7 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input:
             self._async_abort_entries_match({CONF_USERNAME: user_input[CONF_USERNAME]})
@@ -89,12 +64,45 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_NAME: str(user_input[CONF_NAME]).strip(),
             }
 
-            errors = await _validate_input(self.hass, user_input)
-
-            if not errors:
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
+            if not user_input[CONF_NAME]:
+                errors[CONF_NAME] = "invalid_name"
+            else:
+                api = EcovacsMowerApi(
+                    aiohttp_client.async_get_clientsession(self.hass),
+                    username=user_input[CONF_USERNAME],
+                    password=user_input[CONF_PASSWORD],
+                    country=user_input[CONF_COUNTRY],
+                    device_id=get_client_device_id(self.hass),
                 )
+
+                try:
+                    await api.authenticate()
+                    devices = await api.get_devices()
+                except EcovacsDeviceVerificationRequiredError:
+                    self._user_input = user_input
+                    self._api = api
+                    try:
+                        await api.request_device_verification_code()
+                    except (ClientError, EcovacsApiError):
+                        _LOGGER.debug("Cannot send verification code", exc_info=True)
+                        errors["base"] = "cannot_connect"
+                    else:
+                        return await self.async_step_verify_device()
+                except EcovacsAuthError:
+                    errors["base"] = "invalid_auth"
+                except (ClientError, EcovacsApiError):
+                    _LOGGER.debug("Cannot connect", exc_info=True)
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception("Unexpected exception during login")
+                    errors["base"] = "unknown"
+                else:
+                    if not devices:
+                        errors["base"] = "unknown"
+                    else:
+                        return self.async_create_entry(
+                            title=user_input[CONF_NAME], data=user_input
+                        )
 
         schema: VolDictType = {
             vol.Required(CONF_NAME): selector.TextSelector(
@@ -121,6 +129,46 @@ class EcovacsConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema(schema), suggested_values=user_input
             ),
             errors=errors,
+            last_step=True,
+        )
+
+    async def async_step_verify_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the one-time email device-verification code."""
+        errors: dict[str, str] = {}
+        assert self._api is not None
+        assert self._user_input is not None
+
+        if user_input is not None:
+            try:
+                await self._api.verify_device(user_input[CONF_VERIFICATION_CODE])
+                devices = await self._api.get_devices()
+            except EcovacsInvalidVerificationCodeError:
+                errors["base"] = "invalid_verification_code"
+            except EcovacsAuthError:
+                errors["base"] = "invalid_auth"
+            except (ClientError, EcovacsApiError):
+                _LOGGER.debug("Cannot connect", exc_info=True)
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during device verification")
+                errors["base"] = "unknown"
+            else:
+                if not devices:
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_create_entry(
+                        title=self._user_input[CONF_NAME], data=self._user_input
+                    )
+
+        return self.async_show_form(
+            step_id="verify_device",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_VERIFICATION_CODE): selector.TextSelector()}
+            ),
+            errors=errors,
+            description_placeholders={"email": self._user_input[CONF_USERNAME]},
             last_step=True,
         )
 

--- a/custom_components/ecovacs_goat_g1/manifest.json
+++ b/custom_components/ecovacs_goat_g1/manifest.json
@@ -16,7 +16,8 @@
     "paho.mqtt.client"
   ],
   "requirements": [
-    "paho-mqtt==2.1.0"
+    "paho-mqtt==2.1.0",
+    "cryptography"
   ],
   "version": "0.2.0"
 }

--- a/custom_components/ecovacs_goat_g1/mower_api.py
+++ b/custom_components/ecovacs_goat_g1/mower_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
 from datetime import datetime
 import hashlib
@@ -12,6 +13,8 @@ from urllib.parse import urljoin
 from uuid import uuid4
 
 from aiohttp import ClientError, ClientResponseError, ClientSession, ClientTimeout
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from .debug_capture import DebugCaptureStore
 from .mower_models import MowerDevice
@@ -28,14 +31,17 @@ AUTH_CLIENT_KEY = "1520391491841"
 # Same as above for the auth-code client.
 AUTH_CLIENT_SECRET = "77ef58ce3afbe337da74aa8c5ab963a9"  # nosemgrep
 GLOBAL_AUTHCODE_PATH = "/v1/global/auth/getAuthCode"
-USER_LOGIN_PATH_FORMAT = (
+PRIVATE_API_PATH_FORMAT = (
     "/v1/private/{country}/{lang}/{deviceId}/{appCode}/{appVersion}/"
-    "{channel}/{deviceType}/user/login"
+    "{channel}/{deviceType}/{endpoint}"
 )
+PUBLIC_KEY_CONFIG = "PUBLIC.KEY.CONFIG"
+ANDROID_MODEL = "Pixel 7"
+ANDROID_SYSTEM = "Android 14"
 META = {
     "lang": "EN",
     "appCode": "global_e",
-    "appVersion": "1.6.3",
+    "appVersion": "3.14.0",
     "channel": "google_play",
     "deviceType": "1",
 }
@@ -102,6 +108,14 @@ class EcovacsAuthError(EcovacsApiError):
     """Authentication failed."""
 
 
+class EcovacsDeviceVerificationRequiredError(EcovacsAuthError):
+    """Device verification (one-time email code) is required before login."""
+
+
+class EcovacsInvalidVerificationCodeError(EcovacsAuthError):
+    """The supplied device-verification code was invalid or expired."""
+
+
 @dataclass(frozen=True)
 class Credentials:
     """ECOVACS credentials."""
@@ -141,6 +155,7 @@ class EcovacsMowerApi:
         self._credentials: Credentials | None = None
         self._sst: dict[str, SstToken] = {}
         self._debug_capture = debug_capture
+        self._public_key: rsa.RSAPublicKey | None = None
 
         postfix = "" if self._country == COUNTRY_CHINA else f"-{self._continent}"
         country_lower = self._country.lower()
@@ -167,19 +182,80 @@ class EcovacsMowerApi:
             or force
             or self._credentials.expires_at < time.time()
         ):
-            login_resp = await self._login_password()
-            user_id = login_resp["uid"]
-            auth_code = await self._auth_code(login_resp["accessToken"], user_id)
-            token_resp = await self._login_by_it_token(user_id, auth_code)
-            if token_resp["userId"] != user_id:
-                user_id = token_resp["userId"]
-            expires_at = time.time() + int(token_resp.get("last", 604800)) / 1000 * 0.99
-            self._credentials = Credentials(
-                user_id=user_id,
-                token=token_resp["token"],
-                expires_at=expires_at,
-            )
+            login_resp = _expect_dict(await self._login_password(), "Invalid login response")
+            self._credentials = await self._complete_login(login_resp)
         return self._credentials
+
+    async def request_device_verification_code(self) -> None:
+        """Request a one-time email code to verify this integration's device id."""
+        encrypted_email = await self._encrypt_account(self._username)
+        await self._call_private_api(
+            "user/sendEmailVerifyCode",
+            {
+                "encryptEmail": encrypted_email,
+                "verifyType": "EMAIL_VERIFY_DEVICE",
+                "supportChar": "N",
+                "isForce": "N",
+            },
+        )
+
+    async def verify_device(self, verification_code: str) -> Credentials:
+        """Verify this integration's device id using a one-time email code."""
+        encrypted_account = await self._encrypt_account(self._username)
+        response = await self._call_private_api(
+            "user/verifyDevice",
+            {
+                "encryptAccount": encrypted_account,
+                "backUpEmail": "",
+                "verifyCode": verification_code.strip(),
+                "model": ANDROID_MODEL,
+                "system": ANDROID_SYSTEM,
+            },
+        )
+        login_resp = _expect_dict(response, "Invalid verifyDevice response")
+        self._credentials = await self._complete_login(login_resp)
+        return self._credentials
+
+    async def _complete_login(self, login_resp: dict[str, Any]) -> Credentials:
+        """Finish the login sequence given a user/login-shaped response."""
+        user_id = login_resp["uid"]
+        auth_code = await self._auth_code(login_resp["accessToken"], user_id)
+        token_resp = await self._login_by_it_token(user_id, auth_code)
+        if token_resp["userId"] != user_id:
+            user_id = token_resp["userId"]
+        expires_at = time.time() + int(token_resp.get("last", 604800)) / 1000 * 0.99
+        return Credentials(
+            user_id=user_id,
+            token=token_resp["token"],
+            expires_at=expires_at,
+        )
+
+    async def _get_public_key(self) -> rsa.RSAPublicKey:
+        """Fetch (and cache) the RSA public key used to encrypt the account id."""
+        if self._public_key is not None:
+            return self._public_key
+
+        response = await self._call_private_api(
+            "common/getConfig", {"keys": PUBLIC_KEY_CONFIG}
+        )
+        if not isinstance(response, list):
+            raise EcovacsAuthError("Invalid public key configuration response")
+
+        for entry in response:
+            if (
+                isinstance(entry, dict)
+                and entry.get("key") == PUBLIC_KEY_CONFIG
+                and isinstance(entry.get("value"), str)
+            ):
+                self._public_key = _load_public_key(entry["value"])
+                return self._public_key
+
+        raise EcovacsAuthError("Ecovacs public key configuration is missing")
+
+    async def _encrypt_account(self, account: str) -> str:
+        public_key = await self._get_public_key()
+        encrypted = public_key.encrypt(account.encode(), padding.PKCS1v15())
+        return base64.b64encode(encrypted).decode()
 
     async def get_devices(self) -> list[MowerDevice]:
         """Return mower-like eco-ng devices from the account."""
@@ -359,21 +435,30 @@ class EcovacsMowerApi:
         self._sst[device.did] = cached
         return cached
 
-    async def _login_password(self) -> dict[str, Any]:
+    async def _login_password(self) -> Any:
+        return await self._call_private_api(
+            "user/login",
+            {"account": self._username, "password": self._password_hash},
+        )
+
+    async def _call_private_api(self, endpoint: str, params: dict[str, Any]) -> Any:
+        """Call a signed private ECOVACS authentication endpoint."""
         meta = {
             **META,
             "country": country_api_code(self._country),
             "deviceId": self._device_id,
         }
-        params: dict[str, str | int] = {
-            "account": self._username,
-            "password": self._password_hash,
+        url = urljoin(
+            self._login_url,
+            PRIVATE_API_PATH_FORMAT.format(endpoint=endpoint, **meta),
+        )
+        request_params: dict[str, str | int] = {
+            **params,
             "requestId": md5(str(time.time())),
             "authTimespan": int(time.time() * 1000),
             "authTimeZone": "GMT-8",
         }
-        url = urljoin(self._login_url, USER_LOGIN_PATH_FORMAT.format(**meta))
-        return await self._signed_get(url, params, meta, CLIENT_KEY, CLIENT_SECRET)
+        return await self._signed_get(url, request_params, meta, CLIENT_KEY, CLIENT_SECRET)
 
     async def _auth_code(self, access_token: str, user_id: str) -> str:
         params: dict[str, str | int] = {
@@ -384,8 +469,11 @@ class EcovacsMowerApi:
             "authTimespan": int(time.time() * 1000),
         }
         url = urljoin(self._auth_code_url, GLOBAL_AUTHCODE_PATH)
-        data = await self._signed_get(
-            url, params, {"openId": "global"}, AUTH_CLIENT_KEY, AUTH_CLIENT_SECRET
+        data = _expect_dict(
+            await self._signed_get(
+                url, params, {"openId": "global"}, AUTH_CLIENT_KEY, AUTH_CLIENT_SECRET
+            ),
+            "Invalid auth code response",
         )
         return str(data["authCode"])
 
@@ -417,15 +505,23 @@ class EcovacsMowerApi:
         extra: dict[str, str | int],
         key: str,
         secret: str,
-    ) -> dict[str, Any]:
+    ) -> Any:
         signed = sign_params(params, extra, key, secret)
         async with self._session.get(url, params=signed, timeout=TIMEOUT) as response:
             response.raise_for_status()
             result: dict[str, Any] = await response.json(content_type=None)
-        if result.get("code") == "0000":
-            return result["data"]
-        if result.get("code") in ("1005", "1010"):
+        if not isinstance(result, dict):
+            raise EcovacsAuthError(f"Invalid auth response: {result!r}")
+        code = result.get("code")
+        if code == "0000":
+            return result.get("data")
+        message = result.get("msg", "")
+        if code in ("1005", "1010"):
             raise EcovacsAuthError("invalid credentials")
+        if code == "1012":
+            raise EcovacsInvalidVerificationCodeError(message)
+        if code == "1013":
+            raise EcovacsDeviceVerificationRequiredError(message)
         raise EcovacsAuthError(f"auth call failed: {result}")
 
     async def _post_authenticated(
@@ -453,6 +549,34 @@ class EcovacsMowerApi:
                 return result
         except ClientResponseError as err:
             raise EcovacsApiError(f"POST {path} failed") from err
+
+
+def _expect_dict(value: Any, error: str) -> dict[str, Any]:
+    """Verify that an ECOVACS API response is an object, not a list/None."""
+    if not isinstance(value, dict):
+        raise EcovacsAuthError(error)
+    return value
+
+
+def _load_public_key(config_value: str) -> rsa.RSAPublicKey:
+    """Parse the RSA public key out of a getConfig PUBLIC.KEY.CONFIG value."""
+    try:
+        encoded_key = json.loads(config_value)["publicKey"]
+    except (KeyError, TypeError, json.JSONDecodeError) as ex:
+        raise EcovacsAuthError("Invalid Ecovacs public key") from ex
+    if not isinstance(encoded_key, str):
+        raise EcovacsAuthError("Invalid Ecovacs public key")
+
+    try:
+        key = serialization.load_der_public_key(
+            base64.b64decode(encoded_key, validate=True)
+        )
+    except ValueError as ex:
+        raise EcovacsAuthError("Invalid Ecovacs public key") from ex
+
+    if not isinstance(key, rsa.RSAPublicKey):
+        raise EcovacsAuthError("Ecovacs public key is not an RSA key")
+    return key
 
 
 def app_payload(data: Any) -> dict[str, Any]:

--- a/custom_components/ecovacs_goat_g1/strings.json
+++ b/custom_components/ecovacs_goat_g1/strings.json
@@ -7,7 +7,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "invalid_name": "Enter a name."
+      "invalid_name": "Enter a name.",
+      "invalid_verification_code": "That verification code is invalid or has expired."
     },
     "step": {
       "user": {
@@ -16,6 +17,13 @@
           "country": "[%key:common::config_flow::data::country%]",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]"
+        }
+      },
+      "verify_device": {
+        "title": "Verify this device",
+        "description": "Ecovacs sent a one-time verification code to {email}. Enter it below to finish setup.",
+        "data": {
+          "verification_code": "Verification code"
         }
       }
     }

--- a/requirements-audit.txt
+++ b/requirements-audit.txt
@@ -3,3 +3,4 @@
 paho-mqtt==2.1.0
 pytest
 aiohttp
+cryptography

--- a/tests/ecovacs_goat_g1/test_mower_api_auth.py
+++ b/tests/ecovacs_goat_g1/test_mower_api_auth.py
@@ -1,0 +1,78 @@
+"""Tests for ECOVACS device-verification auth helpers."""
+
+import base64
+import json
+from pathlib import Path
+import sys
+import types
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
+import pytest
+
+PACKAGE_PATH = Path(__file__).parents[2] / "custom_components" / "ecovacs_goat_g1"
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [str(PACKAGE_PATH.parent)]
+sys.modules.setdefault("custom_components", custom_components)
+
+ecovacs_goat_g1 = types.ModuleType("custom_components.ecovacs_goat_g1")
+ecovacs_goat_g1.__path__ = [str(PACKAGE_PATH)]
+sys.modules.setdefault("custom_components.ecovacs_goat_g1", ecovacs_goat_g1)
+
+from custom_components.ecovacs_goat_g1.mower_api import (  # noqa: E402
+    EcovacsAuthError,
+    _expect_dict,
+    _load_public_key,
+)
+
+
+def _config_value(encoded_key: str) -> str:
+    return json.dumps({"publicKey": encoded_key})
+
+
+def test_load_public_key_parses_valid_rsa_der() -> None:
+    """A getConfig-shaped value wrapping a real RSA DER key parses cleanly."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    der = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    encoded = base64.b64encode(der).decode()
+
+    key = _load_public_key(_config_value(encoded))
+
+    assert isinstance(key, rsa.RSAPublicKey)
+
+
+def test_load_public_key_rejects_invalid_json() -> None:
+    with pytest.raises(EcovacsAuthError):
+        _load_public_key("not json")
+
+
+def test_load_public_key_rejects_invalid_base64() -> None:
+    with pytest.raises(EcovacsAuthError):
+        _load_public_key(_config_value("not-base64!!"))
+
+
+def test_load_public_key_rejects_non_rsa_key() -> None:
+    """A structurally valid DER key of the wrong type is rejected, not misused."""
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    der = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    encoded = base64.b64encode(der).decode()
+
+    with pytest.raises(EcovacsAuthError):
+        _load_public_key(_config_value(encoded))
+
+
+def test_expect_dict_passes_through_dicts() -> None:
+    payload = {"uid": "abc"}
+    assert _expect_dict(payload, "error") is payload
+
+
+def test_expect_dict_rejects_non_dicts() -> None:
+    with pytest.raises(EcovacsAuthError):
+        _expect_dict(["not", "a", "dict"], "invalid shape")


### PR DESCRIPTION
## Summary

ECOVACS recently started gating login behind an app-version check: the
old `appVersion: 1.6.3` this integration sends is now rejected outright
with `code 1013 ("Please update to the latest version to continue")`.
The updated flow also requires one-time **email device verification**
for device ids ECOVACS hasn't seen before — the same change
[DeebotUniverse/client.py#1706](https://github.com/DeebotUniverse/client.py/pull/1706)
added for the vacuum-side client. This PR ports that flow here:

- Bump `appVersion` to `3.14.0` (matching the current official app).
- Add the `common/getConfig`, `user/sendEmailVerifyCode`, and
  `user/verifyDevice` private API calls, RSA-encrypting the account id
  with the fetched public key (PKCS1v15), same as the official app.
- Add `EcovacsDeviceVerificationRequiredError` (code 1013) and
  `EcovacsInvalidVerificationCodeError` (code 1012) so the config flow
  can react explicitly instead of surfacing a generic `invalid_auth`.
- Add a second config-flow step (`verify_device`) that requests the
  emailed code and completes login once entered.
- Add `cryptography` to `manifest.json` requirements (already a core
  Home Assistant dependency, so no new install footprint in practice).
- Document the new verification step in the README's Setup section.
- Add focused tests for the new RSA public-key parsing/guard helpers
  (`tests/ecovacs_goat_g1/test_mower_api_auth.py`).

**Verified end-to-end** against a live GOAT G1-800 account that was
being rejected with code 1013 under the old flow — login now completes
the email-verification step and the mower's live map/sensors/controls
all work as before.

Per this repo's `CONTRIBUTING.md`, I kept this scoped to the mower auth
path only — no vacuum/`deebot-client`/XMPP code, no new polling.

## Note on CI

`.github/workflows/validate.yml`'s `tests` job currently only runs
`test_mower_messages.py` and doesn't install `cryptography`. I didn't
touch that file (my token lacks the `workflow` scope required to push
workflow-file changes), but for the new test file to run in CI it
would need:

```diff
- run: python -m pip install pytest aiohttp paho-mqtt==2.1.0
+ run: python -m pip install pytest aiohttp paho-mqtt==2.1.0 cryptography
- run: python -m pytest tests/ecovacs_goat_g1/test_mower_messages.py
+ run: python -m pytest tests/ecovacs_goat_g1/test_mower_messages.py tests/ecovacs_goat_g1/test_mower_api_auth.py
```

I ran the full suite locally (`pytest tests/ecovacs_goat_g1/`) with
`pytest`, `aiohttp`, `paho-mqtt==2.1.0`, and `cryptography` installed —
all pass except 4 pre-existing `test_mower_compat.py` async tests that
fail in my environment purely because `pytest-asyncio` isn't installed
(unrelated to this change, and not part of CI's `tests` job either).

## Test plan

- [x] `python -m pytest tests/ecovacs_goat_g1/test_mower_api_auth.py` — new tests pass
- [x] `python -m pytest tests/ecovacs_goat_g1/test_mower_messages.py` — still passes (29 passed)
- [x] `python -m compileall custom_components/ecovacs_goat_g1 tests/ecovacs_goat_g1` — clean
- [x] Live login against a real GOAT G1-800 account previously failing with code 1013
- [x] Post-login: live map, sensors, and controls confirmed working via the bundled dashboard card